### PR TITLE
Parallelize a part of `ImageFrame::autogenerateMappings`

### DIFF
--- a/ProvinceMapper/Source/LinkMapper/Automapper.cpp
+++ b/ProvinceMapper/Source/LinkMapper/Automapper.cpp
@@ -6,21 +6,28 @@
 #include <ranges>
 #include <wx/taskbarbutton.h>
 
+static void incrementShare(std::map<std::string, int>& shares, const std::string& provID)
+{
+	if (shares.contains(provID))
+	{
+		shares[provID]++;
+	}
+	else
+	{
+		shares[provID] = 1;
+	}
+}
+
 void Automapper::registerMatch(const std::shared_ptr<Province>& srcProvince, const std::shared_ptr<Province>& targetProvince)
 {
+	std::lock_guard lock(automapperMutex); // Lock the mutex
+
 	const auto& srcProvinceID = srcProvince->ID;
 	const auto& targetProvinceID = targetProvince->ID;
 
 	if (sourceProvinceShares.contains(srcProvinceID))
 	{
-		if (sourceProvinceShares[srcProvinceID].contains(targetProvinceID))
-		{
-			sourceProvinceShares[srcProvinceID][targetProvinceID]++;
-		}
-		else
-		{
-			sourceProvinceShares[srcProvinceID][targetProvinceID] = 1;
-		}
+		incrementShare(sourceProvinceShares[srcProvinceID], targetProvinceID);
 	}
 	else
 	{
@@ -35,14 +42,7 @@ void Automapper::registerMatch(const std::shared_ptr<Province>& srcProvince, con
 
 	if (targetProvinceShares.contains(targetProvinceID))
 	{
-		if (targetProvinceShares[targetProvinceID].contains(srcProvinceID))
-		{
-			targetProvinceShares[targetProvinceID][srcProvinceID]++;
-		}
-		else
-		{
-			targetProvinceShares[targetProvinceID][srcProvinceID] = 1;
-		}
+		incrementShare(targetProvinceShares[targetProvinceID], srcProvinceID);
 	}
 	else
 	{

--- a/ProvinceMapper/Source/LinkMapper/Automapper.h
+++ b/ProvinceMapper/Source/LinkMapper/Automapper.h
@@ -42,5 +42,5 @@ class Automapper final
 
 	std::shared_ptr<LinkMappingVersion> activeVersion;
 
-   std::mutex automapperMutex; // Mutex for thread safety
+	std::mutex automapperMutex; // Mutex for thread safety
 };

--- a/ProvinceMapper/Source/LinkMapper/Automapper.h
+++ b/ProvinceMapper/Source/LinkMapper/Automapper.h
@@ -2,6 +2,7 @@
 #include "LinkMappingVersion.h"
 
 #include <map>
+#include <mutex>
 #include <string>
 
 class wxTaskBarButton;
@@ -40,4 +41,6 @@ class Automapper final
 	std::set<std::string> alreadyMappedTgtProvincesCache;
 
 	std::shared_ptr<LinkMappingVersion> activeVersion;
+
+   std::mutex automapperMutex; // Mutex for thread safety
 };


### PR DESCRIPTION
Made a rough benchmark on Ryzen 7 7700, with I:R Terra Indomita to CK3 Rajas of Asia mappings being generated. The time was only measured for the relevant loop.

before:
> Elapsed time (sec): 128.072
> Elapsed time (sec): 174.737
> Elapsed time (sec): 158.26
> Elapsed time (sec): 159.164
> Elapsed time (sec): 156.103

after: 
> Elapsed time (sec): 34.02
> Elapsed time (sec): 76.0615
> Elapsed time (sec): 70.8512
> Elapsed time (sec): 71.7781
> Elapsed time (sec): 69.4187