### PR TITLE
Further optimizations for province automapping

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,6 @@
 [submodule "TrianglePP"]
 	path = TrianglePP
 	url = https://github.com/mrkkrj/TrianglePP.git
-[submodule "robin-hood-hashing"]
-	path = robin-hood-hashing
-	url = https://github.com/martinus/robin-hood-hashing.git
+[submodule "gtl"]
+	path = gtl
+	url = https://github.com/greg7mdp/gtl

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "TrianglePP"]
 	path = TrianglePP
 	url = https://github.com/mrkkrj/TrianglePP.git
+[submodule "robin-hood-hashing"]
+	path = robin-hood-hashing
+	url = https://github.com/martinus/robin-hood-hashing.git

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 The Paradox Game Converters Group
+Copyright (c) 2024 The Paradox Game Converters Group
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,29 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-Targa reader/writer code http://dmr.ath.cx/gfx/targa/
-
-Copyright © 2001-2004 Emil Mikulic.
-
-Source and binary redistribution of this code, with or without changes, for free or for profit, is allowed as long as this copyright notice is kept intact. Modified versions have to be clearly marked as modified.
-
-This code is provided without any warranty. The copyright holder is not liable for anything bad that might happen as a result of the code.
-
----
-
- Copyright 2020 The Paradox Game Converters Group
-
-   Licensed under the ImageMagick License (the "License"); you may not use
-   this file except in compliance with the License.  You may obtain a copy
-   of the License at
-
-     https://imagemagick.org/script/license.php
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-   License for the specific language governing permissions and limitations
-   under the License.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,246 @@
+
+# THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+
+This project utilizes the following OSS (Open Source Software):
+
+## Targa reader/writer code
+
+http://dmr.ath.cx/gfx/targa/
+
+Copyright © 2001-2004 Emil Mikulic.
+
+Source and binary redistribution of this code, with or without changes, for free or for profit, is allowed as long as this copyright notice is kept intact. Modified versions have to be clearly marked as modified.
+
+This code is provided without any warranty. The copyright holder is not liable for anything bad that might happen as a result of the code.
+
+## ImageMagick
+
+https://github.com/ImageMagick/ImageMagick
+
+ Copyright 2020 The Paradox Game Converters Group
+
+   Licensed under the ImageMagick License (the "License"); you may not use
+   this file except in compliance with the License.  You may obtain a copy
+   of the License at
+
+     https://imagemagick.org/script/license.php
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+   License for the specific language governing permissions and limitations
+   under the License.
+
+## Greg's Template Library
+
+https://github.com/greg7mdp/gtl
+
+Licensed under the Apache License, Version 2.0.
+
+# License Text
+License text content for the aformentioned packages are reproduced below.
+
+## Apache License 2.0
+```text
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+```

--- a/ProvinceMapper.vcxproj
+++ b/ProvinceMapper.vcxproj
@@ -118,6 +118,12 @@
     <CopyFileToFolders Include="README.md">
       <FileType>Document</FileType>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="LICENSE">
+      <FileType>Document</FileType>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="NOTICE.md">
+      <FileType>Document</FileType>
+    </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="wxWidgets\3.2.1\lib\vc14x_x64_dll\wxbase32u_vc14x_x64.dll">
@@ -159,7 +165,7 @@
       </PrecompiledHeader>
       <PreprocessorDefinitions>WXUSINGDLL;_CRT_SECURE_NO_WARNINGS;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)ProvinceMapper\Source;$(ProjectDir)wxWidgets\3.2.1\include\msvc;$(ProjectDir)commonItems;$(ProjectDir)TrianglePP\source;$(ProjectDir)robin-hood-hashing\src\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)ProvinceMapper\Source;$(ProjectDir)wxWidgets\3.2.1\include\msvc;$(ProjectDir)commonItems;$(ProjectDir)TrianglePP\source;$(ProjectDir)gtl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>

--- a/ProvinceMapper.vcxproj
+++ b/ProvinceMapper.vcxproj
@@ -159,7 +159,7 @@
       </PrecompiledHeader>
       <PreprocessorDefinitions>WXUSINGDLL;_CRT_SECURE_NO_WARNINGS;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)ProvinceMapper\Source;$(ProjectDir)wxWidgets\3.2.1\include\msvc;$(ProjectDir)commonItems;$(ProjectDir)TrianglePP\source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)ProvinceMapper\Source;$(ProjectDir)wxWidgets\3.2.1\include\msvc;$(ProjectDir)commonItems;$(ProjectDir)TrianglePP\source;$(ProjectDir)robin-hood-hashing\src\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>

--- a/ProvinceMapper.vcxproj.filters
+++ b/ProvinceMapper.vcxproj.filters
@@ -194,7 +194,6 @@
     <ClCompile Include="ProvinceMapper\Source\Frames\Links\TriangulationPairDialogComment.cpp" />
     <ClCompile Include="TrianglePP\source\tpp_assert.cpp" />
     <ClCompile Include="TrianglePP\source\tpp_impl.cpp" />
-    <ClCompile Include="robin-hood-hashing\src\robin_hood.cpp" />
     <ClCompile Include="ProvinceMapper\Source\LinkMapper\Triangle.cpp" />
     <ClCompile Include="ProvinceMapper\Source\LinkMapper\Automapper.cpp" />
   </ItemGroup>
@@ -342,6 +341,12 @@
       <Filter>Resources</Filter>
     </CopyFileToFolders>
     <CopyFileToFolders Include="README.md">
+      <Filter>Resources</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="LICENSE">
+      <Filter>Resources</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="NOTICE.md">
       <Filter>Resources</Filter>
     </CopyFileToFolders>
     <CopyFileToFolders Include="wxWidgets\3.2.1\lib\vc14x_x64_dll\wxbase32u_vc14x_x64.dll">

--- a/ProvinceMapper.vcxproj.filters
+++ b/ProvinceMapper.vcxproj.filters
@@ -194,6 +194,7 @@
     <ClCompile Include="ProvinceMapper\Source\Frames\Links\TriangulationPairDialogComment.cpp" />
     <ClCompile Include="TrianglePP\source\tpp_assert.cpp" />
     <ClCompile Include="TrianglePP\source\tpp_impl.cpp" />
+    <ClCompile Include="robin-hood-hashing\src\robin_hood.cpp" />
     <ClCompile Include="ProvinceMapper\Source\LinkMapper\Triangle.cpp" />
     <ClCompile Include="ProvinceMapper\Source\LinkMapper\Automapper.cpp" />
   </ItemGroup>

--- a/ProvinceMapper/Source/Definitions/Definitions.cpp
+++ b/ProvinceMapper/Source/Definitions/Definitions.cpp
@@ -133,26 +133,26 @@ void Definitions::parseStream(std::istream& theStream, const LocalizationMapper&
 					const auto& locName = localizationMapper.getLocForSourceKey(*regName);
 					if (locName && !locName->empty())
 					{
-						province->areaName = *locName;
+						province->setAreaName(*locName);
 					}
 					else
-						province->areaName = *regName;
+						province->setAreaName(*regName);
 				}
 				if (const auto& regName = eu4RegionManager.getParentRegionName(province->ID); regName)
 				{
 					const auto& locName = localizationMapper.getLocForSourceKey(*regName);
 					if (locName && !locName->empty())
-						province->regionName = *locName;
+						province->setRegionName(*locName);
 					else
-						province->regionName = *regName;
+						province->setRegionName(*regName);
 				}
 				if (const auto& regName = eu4RegionManager.getParentSuperRegionName(province->ID); regName)
 				{
 					const auto& locName = localizationMapper.getLocForSourceKey(*regName);
 					if (locName && !locName->empty())
-						province->superRegionName = *locName;
+						province->setSuperRegionName(*locName);
 					else
-						province->superRegionName = *regName;
+						province->setSuperRegionName(*regName);
 				}
 				provinces.insert(std::pair(province->ID, province));
 				chromaCache.insert(std::pair(pixelPack(province->r, province->g, province->b), province));
@@ -304,7 +304,7 @@ void Definitions::tryToLoadProvinceTypes(const std::string& mapDataPath)
 			for (auto& id: provIds)
 			{
 				if (provinces.contains(id) && provinces.at(id))
-					provinces[id]->provinceType = lowerCaseProvinceType;
+					provinces[id]->setProvinceType(lowerCaseProvinceType);
 			}
 		}
 		else if (strOfItemStr == "RANGE") // format found in Imperator and CK3
@@ -322,7 +322,7 @@ void Definitions::tryToLoadProvinceTypes(const std::string& mapDataPath)
 			{
 				std::string idStr = std::to_string(id);
 				if (provinces.contains(idStr) && provinces.at(idStr))
-					provinces[idStr]->provinceType = lowerCaseProvinceType;
+					provinces[idStr]->setProvinceType(lowerCaseProvinceType);
 			}
 		}
 		else if (strOfItemStr.find("{") == 0) // simple list
@@ -333,7 +333,7 @@ void Definitions::tryToLoadProvinceTypes(const std::string& mapDataPath)
 
 			for (auto& id: provIds)
 			{
-				provinces[id]->provinceType = lowerCaseProvinceType;
+				provinces[id]->setProvinceType(lowerCaseProvinceType);
 			}
 		}
 		else

--- a/ProvinceMapper/Source/Definitions/Definitions.h
+++ b/ProvinceMapper/Source/Definitions/Definitions.h
@@ -3,7 +3,7 @@
 #include "DefinitionsInterface.h"
 #include "EU4Regions/RegionManager.h"
 
-struct Province;
+class Province;
 class Definitions: public DefinitionsInterface
 {
   public:

--- a/ProvinceMapper/Source/Definitions/DefinitionsInterface.h
+++ b/ProvinceMapper/Source/Definitions/DefinitionsInterface.h
@@ -8,7 +8,7 @@
 #include <string>
 
 
-struct Province;
+class Province;
 
 
 class DefinitionsInterface

--- a/ProvinceMapper/Source/Definitions/Vic3Definitions.cpp
+++ b/ProvinceMapper/Source/Definitions/Vic3Definitions.cpp
@@ -123,7 +123,7 @@ void Vic3Definitions::loadLocalizations(const LocalizationMapper& localizationMa
 		if (locType == LocalizationMapper::LocType::SOURCE && localizationMapper.getLocForSourceKey(id))
 		{
 			auto stateName = *localizationMapper.getLocForSourceKey(id);
-			province->areaName = stateName;
+			province->setAreaName(stateName);
 
 			if (const auto& cmatch = localizationMapper.getLocForSourceKey(id + "_city"); cmatch)
 			{
@@ -177,31 +177,31 @@ void Vic3Definitions::loadLocalizations(const LocalizationMapper& localizationMa
 			}
 			if (!province->locName)
 			{
-				province->locName = province->areaName;
+				province->locName = province->getAreaName();
 			}
 
 			if (const auto& match = localizationMapper.getLocForSourceKey(stateName); match)
-				province->areaName = *match;
+				province->setAreaName(*match);
 			if (const auto& regionName = vic3regions.getParentRegionName(stateName); regionName)
 			{
 				if (const auto& match = localizationMapper.getLocForSourceKey(*regionName); match)
-					province->regionName = *match;
+					province->setRegionName(*match);
 				else
-					province->regionName = *regionName;
+					province->setRegionName(*regionName);
 			}
 			if (const auto& regionName = vic3regions.getParentSuperRegionName(stateName); regionName)
 			{
 				if (const auto& match = localizationMapper.getLocForSourceKey(*regionName); match)
-					province->superRegionName = *match;
+					province->setSuperRegionName(*match);
 				else
-					province->superRegionName = *regionName;
+					province->setSuperRegionName(*regionName);
 			}
 		}
 
 		if (locType == LocalizationMapper::LocType::TARGET && localizationMapper.getLocForTargetKey(id))
 		{
 			auto stateName = *localizationMapper.getLocForTargetKey(id);
-			province->areaName = stateName;
+			province->setAreaName(stateName);
 
 			if (const auto& cmatch = localizationMapper.getLocForTargetKey(id + "_city"); cmatch)
 			{
@@ -255,24 +255,24 @@ void Vic3Definitions::loadLocalizations(const LocalizationMapper& localizationMa
 			}
 			if (!province->locName)
 			{
-				province->locName = province->areaName;
+				province->locName = province->getAreaName();
 			}
 
 			if (const auto& match = localizationMapper.getLocForTargetKey(stateName); match)
-				province->areaName = *match;
+				province->setAreaName(*match);
 			if (const auto& regionName = vic3regions.getParentRegionName(stateName); regionName)
 			{
 				if (const auto& match = localizationMapper.getLocForTargetKey(*regionName); match)
-					province->regionName = *match;
+					province->setRegionName(*match);
 				else
-					province->regionName = *regionName;
+					province->setRegionName(*regionName);
 			}
 			if (const auto& regionName = vic3regions.getParentSuperRegionName(stateName); regionName)
 			{
 				if (const auto& match = localizationMapper.getLocForTargetKey(*regionName); match)
-					province->superRegionName = *match;
+					province->setSuperRegionName(*match);
 				else
-					province->superRegionName = *regionName;
+					province->setSuperRegionName(*regionName);
 			}
 		}
 	}

--- a/ProvinceMapper/Source/Frames/Images/ImageCanvas.h
+++ b/ProvinceMapper/Source/Frames/Images/ImageCanvas.h
@@ -18,7 +18,7 @@ wxDECLARE_EVENT(wxEVT_SCROLL_RELEASE_V, wxCommandEvent);
 wxDECLARE_EVENT(wxEVT_DELAUNAY_TRIANGULATE, wxCommandEvent);
 
 class wxTipWindow;
-struct Province;
+class Province;
 enum class ImageTabSelector
 {
 	SOURCE,

--- a/ProvinceMapper/Source/Frames/Images/ImageFrame.cpp
+++ b/ProvinceMapper/Source/Frames/Images/ImageFrame.cpp
@@ -1029,7 +1029,6 @@ bool isPointInsideTriangle(const wxPoint& point, const wxPoint& vertex1, const w
 	return !(hasNeg && hasPos);
 }
 
-
 void ImageFrame::autogenerateMappings()
 {
 	if (taskBarBtn)
@@ -1093,6 +1092,8 @@ void ImageFrame::autogenerateMappings()
 
 	auto automapper = Automapper(activeVersion);
 
+	std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now(); // TODO: Remove this line.
+
 	const auto& tgtProvinceDefinitions = targetCanvas->getDefinitions();
 	if (!tgtPointToProvinceDictInitialized)
 	{
@@ -1142,6 +1143,10 @@ void ImageFrame::autogenerateMappings()
 		 tgtPointToWaterProvinceMap,
 		 targetMapWidth,
 		 targetMapHeight);
+
+   std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now(); // TODO: Remove this line.
+	Log(LogLevel::Notice) << "Elapsed time (sec): " << (std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count()) / 1000000.0;
+
 
 	Log(LogLevel::Debug) << "Determined point matches for all provinces.";
 	if (taskBarBtn)

--- a/ProvinceMapper/Source/Frames/Images/ImageFrame.cpp
+++ b/ProvinceMapper/Source/Frames/Images/ImageFrame.cpp
@@ -12,7 +12,6 @@
 #include <wx/dcbuffer.h>
 #include <wx/splitter.h>
 #include <wx/taskbarbutton.h>
-#include <chrono> // TODO: REMOVE THIS
 
 
 using Delaunay = tpp::Delaunay;
@@ -1031,8 +1030,6 @@ bool isPointInsideTriangle(const wxPoint& point, const wxPoint& vertex1, const w
 }
 
 
-
-
 void ImageFrame::autogenerateMappings()
 {
 	if (taskBarBtn)
@@ -1096,13 +1093,16 @@ void ImageFrame::autogenerateMappings()
 
 	auto automapper = Automapper(activeVersion);
 
-   std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now(); // TODO: Remove this line.
-
 	const auto& tgtProvinceDefinitions = targetCanvas->getDefinitions();
 	if (!tgtPointToProvinceDictInitialized)
 	{
 		for (const auto& tgtProvince: tgtProvinceDefinitions->getProvinces() | std::views::values)
 		{
+			// Don't include the province if it's already mapped.
+			// Mapped province can't be used by the automapper.
+			if (activeVersion->isProvinceMapped(tgtProvince->ID, false) == Mapping::MAPPED)
+				continue;
+
 			if (tgtProvince->isWater())
 			{
 				for (const auto& pixel: tgtProvince->innerPixels)
@@ -1142,9 +1142,6 @@ void ImageFrame::autogenerateMappings()
 		 tgtPointToWaterProvinceMap,
 		 targetMapWidth,
 		 targetMapHeight);
-
-   std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now(); // TODO: Remove this line.
-	Log(LogLevel::Notice) << "Elapsed time (sec): " << (std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count()) / 1000000.0;
 
 	Log(LogLevel::Debug) << "Determined point matches for all provinces.";
 	if (taskBarBtn)

--- a/ProvinceMapper/Source/Frames/Images/ImageFrame.cpp
+++ b/ProvinceMapper/Source/Frames/Images/ImageFrame.cpp
@@ -1092,8 +1092,6 @@ void ImageFrame::autogenerateMappings()
 
 	auto automapper = Automapper(activeVersion);
 
-	std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now(); // TODO: Remove this line.
-
 	const auto& tgtProvinceDefinitions = targetCanvas->getDefinitions();
 	if (!tgtPointToProvinceDictInitialized)
 	{
@@ -1143,10 +1141,6 @@ void ImageFrame::autogenerateMappings()
 		 tgtPointToWaterProvinceMap,
 		 targetMapWidth,
 		 targetMapHeight);
-
-   std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now(); // TODO: Remove this line.
-	Log(LogLevel::Notice) << "Elapsed time (sec): " << (std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count()) / 1000000.0;
-
 
 	Log(LogLevel::Debug) << "Determined point matches for all provinces.";
 	if (taskBarBtn)

--- a/ProvinceMapper/Source/Frames/Images/ImageFrame.h
+++ b/ProvinceMapper/Source/Frames/Images/ImageFrame.h
@@ -1,11 +1,6 @@
 #pragma once
-#include <wx/wxprec.h>
-#ifndef WX_PRECOMP
-#include <wx/wx.h>
-#endif
 #include "Definitions/DefinitionsInterface.h"
 #include "LinkMapper/Automapper.h"
-#include "Provinces/Pixel.h"
 
 #include <optional>
 #include <vector>
@@ -18,7 +13,7 @@ class ImageCanvas;
 enum class ImageTabSelector;
 class Configuration;
 class wxAutoBufferedPaintDC;
-class ImageFrame: public wxFrame
+class ImageFrame final: public wxFrame
 {
   public:
 	ImageFrame(wxWindow* parent,
@@ -75,11 +70,9 @@ class ImageFrame: public wxFrame
 	std::vector<std::shared_ptr<Triangle>> triangles;
 	bool showTriangulationMesh = false;
 
-	inline static void determineTargetProvinceForSourcePixels(const std::shared_ptr<Province>& sourceProvince, const std::vector<Pixel>& sourcePixels, std::map<std::pair<int, int>,
-		std::shared_ptr<Triangle>>&
-		pointToTriangleMap, const std::shared_ptr<LinkMappingVersion>& activeVersion, const std::shared_ptr<
-		DefinitionsInterface>& tgtProvinceDefinitions, int targetMapWidth, int targetMapHeight, bool water, Automapper&
-		automapper);
+   bool tgtPointToProvinceDictInitialized = false;
+	PointToProvinceMap tgtPointToLandProvinceMap;
+	PointToProvinceMap tgtPointToWaterProvinceMap;
 
 	void determineTriangulationSanity();
 	void buildBounds();
@@ -97,8 +90,6 @@ class ImageFrame: public wxFrame
 	bool black = false;
 	bool triangulationIsSane = false;
 	bool lock = false;
-
-	static wxPoint triangulate(const std::vector<wxPoint>& sources, const std::vector<wxPoint>& targets, const wxPoint& sourcePoint);
 
 	std::shared_ptr<Configuration> configuration;
 

--- a/ProvinceMapper/Source/Frames/Images/ImageFrame.h
+++ b/ProvinceMapper/Source/Frames/Images/ImageFrame.h
@@ -4,7 +4,11 @@
 #include <wx/wx.h>
 #endif
 #include "Definitions/DefinitionsInterface.h"
+#include "LinkMapper/Automapper.h"
+#include "Provinces/Pixel.h"
+
 #include <optional>
+#include <vector>
 
 class Triangle;
 class StatusBar;
@@ -70,6 +74,12 @@ class ImageFrame: public wxFrame
 	void delaunayTriangulate();
 	std::vector<std::shared_ptr<Triangle>> triangles;
 	bool showTriangulationMesh = false;
+
+	inline static void determineTargetProvinceForSourcePixels(const std::shared_ptr<Province>& sourceProvince, const std::vector<Pixel>& sourcePixels, std::map<std::pair<int, int>,
+		std::shared_ptr<Triangle>>&
+		pointToTriangleMap, const std::shared_ptr<LinkMappingVersion>& activeVersion, const std::shared_ptr<
+		DefinitionsInterface>& tgtProvinceDefinitions, int targetMapWidth, int targetMapHeight, bool water, Automapper&
+		automapper);
 
 	void determineTriangulationSanity();
 	void buildBounds();

--- a/ProvinceMapper/Source/Frames/Images/ImageFrame.h
+++ b/ProvinceMapper/Source/Frames/Images/ImageFrame.h
@@ -70,7 +70,7 @@ class ImageFrame final: public wxFrame
 	std::vector<std::shared_ptr<Triangle>> triangles;
 	bool showTriangulationMesh = false;
 
-   bool tgtPointToProvinceDictInitialized = false;
+	bool tgtPointToProvinceDictInitialized = false;
 	PointToProvinceMap tgtPointToLandProvinceMap;
 	PointToProvinceMap tgtPointToWaterProvinceMap;
 

--- a/ProvinceMapper/Source/LinkMapper/Automapper.cpp
+++ b/ProvinceMapper/Source/LinkMapper/Automapper.cpp
@@ -1,10 +1,61 @@
 #include "Automapper.h"
 
 #include "Log.h"
+#include "Frames/Images/ImageFrame.h"
+#include "LinkMappingVersion.h"
 #include "Provinces/Province.h"
+#include "Triangle.h"
 
 #include <ranges>
 #include <wx/taskbarbutton.h>
+
+
+wxPoint triangulate(const std::vector<wxPoint>& sources, const std::vector<wxPoint>& targets, const wxPoint& sourcePoint)
+{
+	// move the source point in reference to the source origin
+	const auto movedSource = sourcePoint - sources[0];
+
+	// construct a basis matrix for the source triangle:
+	// ( A B ) = ( x1 x2 )
+	// ( C D ) = ( y1 y2 )
+	const auto sourceA = static_cast<float>(sources[1].x) - static_cast<float>(sources[0].x);
+	const auto sourceB = static_cast<float>(sources[2].x) - static_cast<float>(sources[0].x);
+	const auto sourceC = static_cast<float>(sources[1].y) - static_cast<float>(sources[0].y);
+	const auto sourceD = static_cast<float>(sources[2].y) - static_cast<float>(sources[0].y);
+
+	// construct the inverse of the source basis matrix:
+	// ___1___ ( d -b )
+	// ad - bc (-c  a )
+	const auto sourceDeterminant = 1 / (sourceA * sourceD - sourceB * sourceC);
+	const auto inverseA = sourceDeterminant * sourceD;
+	const auto inverseB = sourceDeterminant * -sourceB;
+	const auto inverseC = sourceDeterminant * -sourceC;
+	const auto inverseD = sourceDeterminant * sourceA;
+
+	// transform the source point into the source triangle basis
+	const auto sourceU = static_cast<float>(movedSource.x) * inverseA + static_cast<float>(movedSource.y) * inverseB;
+	const auto sourceV = static_cast<float>(movedSource.x) * inverseC + static_cast<float>(movedSource.y) * inverseD;
+
+	// silently move from source triangle basis to destination triangle basis
+	const auto targetU = sourceU;
+	const auto targetV = sourceV;
+
+	// construct a basis matrix for the target triangle:
+	// ( A B ) = ( x1 x2 )
+	// ( C D ) = ( y1 y2 )
+	const auto targetA = static_cast<float>(targets[1].x) - static_cast<float>(targets[0].x);
+	const auto targetB = static_cast<float>(targets[2].x) - static_cast<float>(targets[0].x);
+	const auto targetC = static_cast<float>(targets[1].y) - static_cast<float>(targets[0].y);
+	const auto targetD = static_cast<float>(targets[2].y) - static_cast<float>(targets[0].y);
+
+	// transform the target point from the destination triangle basis
+	wxPoint target;
+	target.x = static_cast<int>(std::round(targetU * targetA + targetV * targetB));
+	target.y = static_cast<int>(std::round(targetU * targetC + targetV * targetD));
+
+	// move the target point in reference to the source origin
+	return target + targets[0];
+}
 
 static void incrementShare(std::map<std::string, int>& shares, const std::string& provID)
 {
@@ -15,6 +66,101 @@ static void incrementShare(std::map<std::string, int>& shares, const std::string
 	else
 	{
 		shares[provID] = 1;
+	}
+}
+
+inline void Automapper::determineTargetProvinceForSourcePixels(
+	 const std::shared_ptr<Province>& sourceProvince,
+	 const std::vector<Pixel>& sourcePixels,
+	 const PointToTriangleMap& srcPointToTriangleMap,
+	 const PointToProvinceMap& tgtPointToProvinceMap,
+	 const int targetMapWidth,
+	 const int targetMapHeight)
+{
+	for (const auto& sourcePixel: sourcePixels)
+	{
+		// Only map every other pixel, in order to speed up the loop by about 50% while keeping a perfectly fine accuracy.
+		if ((sourcePixel.x + sourcePixel.y) % 2 == 0)
+			continue;
+
+		const auto sourcePoint = wxPoint(sourcePixel.x, sourcePixel.y);
+		const auto& triangleItr = srcPointToTriangleMap.find(sourcePoint);
+		if (triangleItr == srcPointToTriangleMap.end())
+			throw std::runtime_error("Could not find triangle for source map point " + std::to_string(sourcePixel.x) + ", " + std::to_string(sourcePixel.y));
+		const auto& triangle = triangleItr->second;
+
+		const auto& tgtPoint = triangulate(triangle->getSourcePoints(), triangle->getTargetPoints(), sourcePoint);
+
+		// Skip if tgtPoint is outside the target map.
+		if (tgtPoint.x < 0 || tgtPoint.x >= targetMapWidth || tgtPoint.y < 0 || tgtPoint.y >= targetMapHeight)
+		{
+			continue;
+		}
+
+		// Get tgtProvince from the packed map, or skip if not found.
+		const auto& tgtProvince = tgtPointToProvinceMap.find(tgtPoint);
+		if (tgtProvince == tgtPointToProvinceMap.end())
+		{
+			continue;
+		}
+
+		// Skip if the target province is already mapped (implying a hand-made mapping).
+		if (activeVersion->isProvinceMapped(tgtProvince->second->ID, false) == Mapping::MAPPED)
+			continue;
+
+		registerMatch(sourceProvince, tgtProvince->second);
+	}
+}
+
+void Automapper::matchTargetProvsToSourceProvs(
+	 const std::vector<std::shared_ptr<Province>>& sourceProvinces,
+	 const PointToTriangleMap& srcPointToTriangleMap,
+	 const PointToProvinceMap& tgtPointToProvinceMap,
+	 const int targetMapWidth,
+	 const int targetMapHeight)
+{
+	// Split source provinces into chunks for parallel processing
+	// std::vector sourceProvincesVector(sourceProvinces.begin(), sourceProvinces.end());
+	const size_t numThreads = std::thread::hardware_concurrency();
+	const size_t chunkSize = (sourceProvinces.size() + numThreads - 1) / numThreads;
+
+	std::vector<std::future<void>> futures;
+
+	for (size_t i = 0; i < numThreads; ++i)
+	{
+		auto startIt = sourceProvinces.begin() + i * chunkSize;
+		auto endIt = (i == numThreads - 1) ? sourceProvinces.end() : startIt + chunkSize;
+
+		futures.push_back(std::async(std::launch::async, [&, startIt, endIt] {
+			for (auto it = startIt; it != endIt; ++it)
+			{
+				const auto& sourceProvince = *it;
+
+				// Skip if the source province is already mapped (implying a hand-made mapping).
+				if (activeVersion->isProvinceMapped(sourceProvince->ID, true) == Mapping::MAPPED)
+					continue;
+
+				// Determine which target province every pixel of the source province corresponds to.
+				determineTargetProvinceForSourcePixels(sourceProvince,
+					 sourceProvince->innerPixels,
+					 srcPointToTriangleMap,
+					 tgtPointToProvinceMap,
+					 targetMapWidth,
+					 targetMapHeight);
+				determineTargetProvinceForSourcePixels(sourceProvince,
+					 sourceProvince->borderPixels,
+					 srcPointToTriangleMap,
+					 tgtPointToProvinceMap,
+					 targetMapWidth,
+					 targetMapHeight);
+			}
+		}));
+	}
+
+	// Wait for all tasks to complete
+	for (auto& future: futures)
+	{
+		future.get();
 	}
 }
 

--- a/ProvinceMapper/Source/LinkMapper/Automapper.cpp
+++ b/ProvinceMapper/Source/LinkMapper/Automapper.cpp
@@ -115,7 +115,6 @@ void Automapper::matchTargetProvsToSourceProvs(
 	 const int targetMapHeight)
 {
 	// Split source provinces into chunks for parallel processing
-	// std::vector sourceProvincesVector(sourceProvinces.begin(), sourceProvinces.end());
 	const size_t numThreads = std::thread::hardware_concurrency();
 	const size_t chunkSize = (sourceProvinces.size() + numThreads - 1) / numThreads;
 

--- a/ProvinceMapper/Source/LinkMapper/Automapper.h
+++ b/ProvinceMapper/Source/LinkMapper/Automapper.h
@@ -5,12 +5,10 @@
 #include <wx/wx.h>
 #endif
 
-#include "robin_hood.h"
+#include <gtl/phmap.hpp>
 #include <future>
 #include <map>
 #include <mutex>
-#include <ranges>
-#include <set>
 #include <string>
 
 wxPoint triangulate(const std::vector<wxPoint>& sources, const std::vector<wxPoint>& targets, const wxPoint& sourcePoint);
@@ -25,8 +23,8 @@ struct wxPointHash
 
 class Triangle;
 class Province;
-typedef robin_hood::unordered_map<wxPoint, std::shared_ptr<Triangle>, wxPointHash> PointToTriangleMap;
-typedef robin_hood::unordered_map<wxPoint, std::shared_ptr<Province>, wxPointHash> PointToProvinceMap;
+typedef gtl::flat_hash_map<wxPoint, std::shared_ptr<Triangle>, wxPointHash> PointToTriangleMap;
+typedef gtl::flat_hash_map<wxPoint, std::shared_ptr<Province>, wxPointHash> PointToProvinceMap;
 
 
 struct Pixel;
@@ -38,7 +36,9 @@ class Automapper final
 	
 	void matchTargetProvsToSourceProvs(const std::vector<std::shared_ptr<Province>>& sourceProvinces,
 		 const PointToTriangleMap& srcPointToTriangleMap,
-		 const PointToProvinceMap& tgtPointToProvinceMap,
+		 const PointToProvinceMap& tgtPointToLandProvinceMap,
+		 const PointToProvinceMap& tgtPointToWaterProvinceMap,
+		 const gtl::flat_hash_set<std::string>& excludedTgtProvinceIDs,
 		 int targetMapWidth,
 		 int targetMapHeight);
 	void registerMatch(const std::shared_ptr<Province>& srcProvince, const std::shared_ptr<Province>& targetProvince, int amount);
@@ -65,11 +65,11 @@ class Automapper final
 	std::map<std::string, std::map<std::string, int>> sourceProvinceShares; // src prov ID, <target prov ID, shares>
 	std::map<std::string, std::map<std::string, int>> targetProvinceShares; // target prov ID, <src prov ID, shares>
 
-	std::set<std::string> srcImpassablesCache;
-	std::set<std::string> tgtImpassablesCache;
+	gtl::flat_hash_set<std::string> srcImpassablesCache;
+	gtl::flat_hash_set<std::string> tgtImpassablesCache;
 
-	std::set<std::string> alreadyMappedSrcProvincesCache;
-	std::set<std::string> alreadyMappedTgtProvincesCache;
+	gtl::flat_hash_set<std::string> alreadyMappedSrcProvincesCache;
+	gtl::flat_hash_set<std::string> alreadyMappedTgtProvincesCache;
 
 	std::shared_ptr<LinkMappingVersion> activeVersion;
 
@@ -79,6 +79,7 @@ class Automapper final
 		 const std::vector<Pixel>& sourcePixels,
 		 const PointToTriangleMap& srcPointToTriangleMap,
 		 const PointToProvinceMap& tgtPointToProvinceMap,
+		 const gtl::flat_hash_set<std::string>& excludedTgtProvinceIDs,
 		 int targetMapWidth,
 		 int targetMapHeight);
 };

--- a/ProvinceMapper/Source/LinkMapper/Automapper.h
+++ b/ProvinceMapper/Source/LinkMapper/Automapper.h
@@ -23,15 +23,10 @@ struct wxPointHash
 	std::size_t operator()(const wxPoint& point) const { return std::hash<int>()(point.x) ^ (std::hash<int>()(point.y) << 1); }
 };
 
-struct wxPointEqual
-{
-	bool operator()(const wxPoint& a, const wxPoint& b) const { return a.x == b.x && a.y == b.y; }
-};
-
 class Triangle;
 class Province;
-typedef robin_hood::unordered_map<wxPoint, std::shared_ptr<Triangle>, wxPointHash, wxPointEqual> PointToTriangleMap;
-typedef robin_hood::unordered_map<wxPoint, std::shared_ptr<Province>, wxPointHash, wxPointEqual> PointToProvinceMap;
+typedef robin_hood::unordered_map<wxPoint, std::shared_ptr<Triangle>, wxPointHash> PointToTriangleMap;
+typedef robin_hood::unordered_map<wxPoint, std::shared_ptr<Province>, wxPointHash> PointToProvinceMap;
 
 
 struct Pixel;
@@ -46,7 +41,7 @@ class Automapper final
 		 const PointToProvinceMap& tgtPointToProvinceMap,
 		 int targetMapWidth,
 		 int targetMapHeight);
-	void registerMatch(const std::shared_ptr<Province>& srcProvince, const std::shared_ptr<Province>& targetProvince);
+	void registerMatch(const std::shared_ptr<Province>& srcProvince, const std::shared_ptr<Province>& targetProvince, int amount);
 	void generateLinks(wxTaskBarButton* taskBarBtn);
 
   private:

--- a/ProvinceMapper/Source/LinkMapper/LinkMapping.h
+++ b/ProvinceMapper/Source/LinkMapper/LinkMapping.h
@@ -12,7 +12,7 @@ enum class Mapping
 	UNMAPPED,
 	FAIL
 };
-struct Province;
+class Province;
 class LinkMapping final: public LinkBase
 {
   public:

--- a/ProvinceMapper/Source/LinkMapper/LinkMappingVersion.cpp
+++ b/ProvinceMapper/Source/LinkMapper/LinkMappingVersion.cpp
@@ -462,7 +462,7 @@ void LinkMappingVersion::generateUnmapped() const
 							  << " unmapped target provinces.";
 }
 
-Mapping LinkMappingVersion::isProvinceMapped(const std::string& provinceID, bool isSource) const
+Mapping LinkMappingVersion::isProvinceMapped(const std::string& provinceID, const bool isSource) const
 {
 	if (isSource)
 	{

--- a/ProvinceMapper/Source/Provinces/Province.cpp
+++ b/ProvinceMapper/Source/Provinces/Province.cpp
@@ -43,31 +43,6 @@ bool Province::operator!=(const Province& rhs) const
 	return ID != rhs.ID;
 }
 
-bool Province::isWater() const
-{
-	// For EU4, use region and area names to determine what is water.
-	if (superRegionName && superRegionName.value().ends_with("_sea_superregion"))
-	{
-		return true;
-	}
-	if (regionName && regionName.value().ends_with("_sea_region"))
-	{
-		return true;
-	}
-	if (areaName && areaName.value().ends_with("_sea_area"))
-	{
-		return true;
-	}
-
-	// For games like I:R and CK3, province type is defined and can be used.
-	return provinceType == "sea_zones" || provinceType == "river_provinces" || provinceType == "lakes" || provinceType == "impassable_seas";
-}
-
-bool Province::isImpassable() const
-{
-	return provinceType == "wasteland" || provinceType == "impassable_terrain" || provinceType == "impassable_mountains";
-}
-
 bool Province::operator<(const Province& rhs) const
 {
 	return ID < rhs.ID;
@@ -110,4 +85,29 @@ std::string Province::miscName() const
 	if (superRegionName)
 		name += "\nSuperRegion: " + *superRegionName;
 	return name;
+}
+
+bool Province::isWater() const
+{
+	// For EU4, use region and area names to determine what is water.
+	if (superRegionName && superRegionName.value().ends_with("_sea_superregion"))
+	{
+		return true;
+	}
+	if (regionName && regionName.value().ends_with("_sea_region"))
+	{
+		return true;
+	}
+	if (areaName && areaName.value().ends_with("_sea_area"))
+	{
+		return true;
+	}
+
+	// For games like I:R and CK3, province type is defined and can be used.
+	return provinceType == "sea_zones" || provinceType == "river_provinces" || provinceType == "lakes" || provinceType == "impassable_seas";
+}
+
+bool Province::isImpassable() const
+{
+	return provinceType == "wasteland" || provinceType == "impassable_terrain" || provinceType == "impassable_mountains";
 }

--- a/ProvinceMapper/Source/Provinces/Province.cpp
+++ b/ProvinceMapper/Source/Provinces/Province.cpp
@@ -90,13 +90,3 @@ bool Province::isImpassable() const
 {
 	return provinceType == "wasteland" || provinceType == "impassable_terrain" || provinceType == "impassable_mountains";
 }
-
-std::vector<Pixel> Province::getAllPixels() const
-{
-	std::vector<Pixel> allPixels;
-	allPixels.reserve(innerPixels.size() + borderPixels.size());
-	allPixels.insert(allPixels.end(), innerPixels.begin(), innerPixels.end());
-	allPixels.insert(allPixels.end(), borderPixels.begin(), borderPixels.end());
-
-	return allPixels;
-}

--- a/ProvinceMapper/Source/Provinces/Province.cpp
+++ b/ProvinceMapper/Source/Provinces/Province.cpp
@@ -11,26 +11,21 @@ Province::Province(std::string theID, const unsigned char tr, const unsigned cha
 void Province::setAreaName(std::string name)
 {
 	areaName = std::move(name);
-	determineIfWater();
 }
 
 void Province::setRegionName(std::string name)
 {
 	regionName = std::move(name);
-	determineIfWater();
 }
 
 void Province::setSuperRegionName(std::string name)
 {
 	superRegionName = std::move(name);
-	determineIfWater();
 }
 
 void Province::setProvinceType(std::string name)
 {
 	provinceType = std::move(name);
-	determineIfWater();
-	determineIfImpassable();
 }
 
 bool Province::operator==(const Province& rhs) const
@@ -48,32 +43,29 @@ bool Province::operator!=(const Province& rhs) const
 	return ID != rhs.ID;
 }
 
-void Province::determineIfWater()
+bool Province::isWater() const
 {
 	// For EU4, use region and area names to determine what is water.
 	if (superRegionName && superRegionName.value().ends_with("_sea_superregion"))
 	{
-		water = true;
-		return;
+		return true;
 	}
 	if (regionName && regionName.value().ends_with("_sea_region"))
 	{
-		water = true;
-		return;
+		return true;
 	}
 	if (areaName && areaName.value().ends_with("_sea_area"))
 	{
-		water = true;
-		return;
+		return true;
 	}
 
 	// For games like I:R and CK3, province type is defined and can be used.
-	water = provinceType == "sea_zones" || provinceType == "river_provinces" || provinceType == "lakes" || provinceType == "impassable_seas";
+	return provinceType == "sea_zones" || provinceType == "river_provinces" || provinceType == "lakes" || provinceType == "impassable_seas";
 }
 
-void Province::determineIfImpassable()
+bool Province::isImpassable() const
 {
-	impassable = provinceType == "wasteland" || provinceType == "impassable_terrain" || provinceType == "impassable_mountains";
+	return provinceType == "wasteland" || provinceType == "impassable_terrain" || provinceType == "impassable_mountains";
 }
 
 bool Province::operator<(const Province& rhs) const

--- a/ProvinceMapper/Source/Provinces/Province.cpp
+++ b/ProvinceMapper/Source/Provinces/Province.cpp
@@ -7,6 +7,32 @@ Province::Province(std::string theID, const unsigned char tr, const unsigned cha
 {
 }
 
+
+void Province::setAreaName(std::string name)
+{
+	areaName = std::move(name);
+	determineIfWater();
+}
+
+void Province::setRegionName(std::string name)
+{
+	regionName = std::move(name);
+	determineIfWater();
+}
+
+void Province::setSuperRegionName(std::string name)
+{
+	superRegionName = std::move(name);
+	determineIfWater();
+}
+
+void Province::setProvinceType(std::string name)
+{
+	provinceType = std::move(name);
+	determineIfWater();
+	determineIfImpassable();
+}
+
 bool Province::operator==(const Province& rhs) const
 {
 	return ID == rhs.ID;
@@ -20,6 +46,34 @@ bool Province::operator==(const Pixel& rhs) const
 bool Province::operator!=(const Province& rhs) const
 {
 	return ID != rhs.ID;
+}
+
+void Province::determineIfWater()
+{
+	// For EU4, use region and area names to determine what is water.
+	if (superRegionName && superRegionName.value().ends_with("_sea_superregion"))
+	{
+		water = true;
+		return;
+	}
+	if (regionName && regionName.value().ends_with("_sea_region"))
+	{
+		water = true;
+		return;
+	}
+	if (areaName && areaName.value().ends_with("_sea_area"))
+	{
+		water = true;
+		return;
+	}
+
+	// For games like I:R and CK3, province type is defined and can be used.
+	water = provinceType == "sea_zones" || provinceType == "river_provinces" || provinceType == "lakes" || provinceType == "impassable_seas";
+}
+
+void Province::determineIfImpassable()
+{
+	impassable = provinceType == "wasteland" || provinceType == "impassable_terrain" || provinceType == "impassable_mountains";
 }
 
 bool Province::operator<(const Province& rhs) const
@@ -64,29 +118,4 @@ std::string Province::miscName() const
 	if (superRegionName)
 		name += "\nSuperRegion: " + *superRegionName;
 	return name;
-}
-
-bool Province::isWater() const
-{	
-	// For EU4, use region and area names to determine what is water.
-	if (superRegionName && superRegionName.value().ends_with("_sea_superregion"))
-	{
-		return true;
-	}
-	if (regionName && regionName.value().ends_with("_sea_region"))
-	{
-		return true;
-	}
-	if (areaName && areaName.value().ends_with("_sea_area"))
-	{
-		return true;
-	}
-
-	// For games like I:R and CK3, province type is defined and can be used.
-	return provinceType == "sea_zones" || provinceType == "river_provinces" || provinceType == "lakes" || provinceType == "impassable_seas";
-}
-
-bool Province::isImpassable() const
-{
-	return provinceType == "wasteland" || provinceType == "impassable_terrain" || provinceType == "impassable_mountains";
 }

--- a/ProvinceMapper/Source/Provinces/Province.h
+++ b/ProvinceMapper/Source/Provinces/Province.h
@@ -13,7 +13,6 @@ struct Province
 	[[nodiscard]] std::string miscName() const;
 	[[nodiscard]] bool isWater() const;
 	[[nodiscard]] bool isImpassable() const;
-	[[nodiscard]] std::vector<Pixel> getAllPixels() const;
 
 
 	bool operator==(const Province& rhs) const;

--- a/ProvinceMapper/Source/Provinces/Province.h
+++ b/ProvinceMapper/Source/Provinces/Province.h
@@ -16,8 +16,8 @@ class Province final
 	[[nodiscard]] const std::optional<std::string>& getRegionName() const { return regionName; }
 	[[nodiscard]] const std::optional<std::string>& getSuperRegionName() const { return superRegionName; }
 	[[nodiscard]] const std::optional<std::string>& getProvinceType() const { return provinceType; }
-	[[nodiscard]] bool isWater() const { return water; }
-	[[nodiscard]] bool isImpassable() const { return impassable; }
+	[[nodiscard]] bool isWater() const;
+	[[nodiscard]] bool isImpassable() const;
 
    void setAreaName(std::string name);
 	void setRegionName(std::string name);
@@ -39,16 +39,10 @@ class Province final
 	std::vector<Pixel> borderPixels;
 
   private:
-	void determineIfWater();
-	void determineIfImpassable();
-
 	std::optional<std::string> areaName;
 	std::optional<std::string> regionName;
 	std::optional<std::string> superRegionName;
 	std::optional<std::string> provinceType;
-
-   bool water = false;
-	bool impassable = false;
 };
 
 #endif // PROVINCE_H

--- a/ProvinceMapper/Source/Provinces/Province.h
+++ b/ProvinceMapper/Source/Provinces/Province.h
@@ -5,15 +5,24 @@
 #include <string>
 #include <vector>
 
-struct Province
+class Province final
 {
+  public:
 	Province(std::string theID, unsigned char tr, unsigned char tg, unsigned char tb, std::string theName);
 
 	[[nodiscard]] std::string bespokeName() const;
 	[[nodiscard]] std::string miscName() const;
-	[[nodiscard]] bool isWater() const;
-	[[nodiscard]] bool isImpassable() const;
+	[[nodiscard]] const std::optional<std::string>& getAreaName() const { return areaName; }
+	[[nodiscard]] const std::optional<std::string>& getRegionName() const { return regionName; }
+	[[nodiscard]] const std::optional<std::string>& getSuperRegionName() const { return superRegionName; }
+	[[nodiscard]] const std::optional<std::string>& getProvinceType() const { return provinceType; }
+	[[nodiscard]] bool isWater() const { return water; }
+	[[nodiscard]] bool isImpassable() const { return impassable; }
 
+   void setAreaName(std::string name);
+	void setRegionName(std::string name);
+	void setSuperRegionName(std::string name);
+	void setProvinceType(std::string name);
 
 	bool operator==(const Province& rhs) const;
 	bool operator==(const Pixel& rhs) const;
@@ -28,10 +37,18 @@ struct Province
 	mutable std::string mapDataName;
 	std::vector<Pixel> innerPixels; // Not border pixels, just the inner stuff!
 	std::vector<Pixel> borderPixels;
+
+  private:
+	void determineIfWater();
+	void determineIfImpassable();
+
 	std::optional<std::string> areaName;
 	std::optional<std::string> regionName;
 	std::optional<std::string> superRegionName;
 	std::optional<std::string> provinceType;
+
+   bool water = false;
+	bool impassable = false;
 };
 
 #endif // PROVINCE_H

--- a/ProvinceMapper/Source/Provinces/Province.h
+++ b/ProvinceMapper/Source/Provinces/Province.h
@@ -19,7 +19,7 @@ class Province final
 	[[nodiscard]] bool isWater() const;
 	[[nodiscard]] bool isImpassable() const;
 
-   void setAreaName(std::string name);
+	void setAreaName(std::string name);
 	void setRegionName(std::string name);
 	void setSuperRegionName(std::string name);
 	void setProvinceType(std::string name);


### PR DESCRIPTION
Notable changes:
- Drastically reduced the number of `isProvinceMapped` calls (which turned out to be very expensive).
- Reduced the number of locks when registering source-target province matches, thus increasing the gains from parallelism.
- ~~Included https://github.com/martinus/robin-hood-hashing for its faster (about 2x in my test runs) implementation of `unordered_map`.~~ EDIT: replaced with https://github.com/greg7mdp/gtl
- Made Province struct a class because its instances are quite big, and added some encapsulation.
- Moved some automapping-related code from `ImageFrame` to `Automapper`, which seems a better place for it.
- Some micro-optimizations like making classes `final`.
- A source map pixel is no longer skipped if `(sourcePixel.x + sourcePixel.y) % 2 == 0`. The code is about 32x faster, despite checking all source map pixels instead of only half of them, so it's no longer needed to reduce the mapping accuracy.

Logged time measurements on Ryzen 7 7700, with I:R Terra Indomita to CK3 Rajas of Asia mappings being generated.

before (measured on an older version of Rajas of Asia, but shouldn't matter much):
> Elapsed time (sec): 34.02
> Elapsed time (sec): 76.0615
> Elapsed time (sec): 70.8512
> Elapsed time (sec): 71.7781
> Elapsed time (sec): 69.4187

~~after~~ (see new updated in comment below):
> Elapsed time (sec): 9.58116
> Elapsed time (sec): 2.19897
> Elapsed time (sec): 2.26537
> Elapsed time (sec): 2.25273
> Elapsed time (sec): 2.23148

The first run always takes a longer time, because a point-province map is being initialized. It's reused in subsequent runs.