### PR TITLE
Fixes for loading of Imperator province definitions

### DIFF
--- a/ProvinceMapper/Source/Provinces/Province.cpp
+++ b/ProvinceMapper/Source/Provinces/Province.cpp
@@ -1,5 +1,6 @@
 #include "Province.h"
 #include <algorithm>
+#include <numeric>
 #include <Configuration/Configuration.h>
 
 Province::Province(std::string theID, const unsigned char tr, const unsigned char tg, const unsigned char tb, std::string theName):
@@ -23,9 +24,9 @@ void Province::setSuperRegionName(std::string name)
 	superRegionName = std::move(name);
 }
 
-void Province::setProvinceType(std::string name)
+void Province::addProvinceType(std::string name)
 {
-	provinceType = std::move(name);
+	provinceTypes.emplace(std::move(name));
 }
 
 bool Province::operator==(const Province& rhs) const
@@ -68,10 +69,16 @@ std::string Province::miscName() const
 {
 	std::string name;
 
-	name = "\nType: ";
-	if (provinceType)
+	name = "\nTypes: ";
+	if (!provinceTypes.empty())
 	{
-		name += *provinceType;
+		name += std::accumulate(
+			 ++provinceTypes.begin(),
+			 provinceTypes.end(),
+			 *provinceTypes.begin(), 
+			 [](const std::string& a, const std::string& b) {
+				 return a + ", " + b;
+			 });
 	}
 	else
 	{
@@ -104,10 +111,10 @@ bool Province::isWater() const
 	}
 
 	// For games like I:R and CK3, province type is defined and can be used.
-	return provinceType == "sea_zones" || provinceType == "river_provinces" || provinceType == "lakes" || provinceType == "impassable_seas";
+	return provinceTypes.contains("sea_zones") || provinceTypes.contains("river_provinces") || provinceTypes.contains("lakes") || provinceTypes.contains("impassable_seas");
 }
 
 bool Province::isImpassable() const
 {
-	return provinceType == "wasteland" || provinceType == "impassable_terrain" || provinceType == "impassable_mountains";
+	return provinceTypes.contains("wasteland") || provinceTypes.contains("impassable_terrain") || provinceTypes.contains("impassable_mountains");
 }

--- a/ProvinceMapper/Source/Provinces/Province.h
+++ b/ProvinceMapper/Source/Provinces/Province.h
@@ -4,6 +4,7 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include <set>
 
 class Province final
 {
@@ -15,14 +16,14 @@ class Province final
 	[[nodiscard]] const std::optional<std::string>& getAreaName() const { return areaName; }
 	[[nodiscard]] const std::optional<std::string>& getRegionName() const { return regionName; }
 	[[nodiscard]] const std::optional<std::string>& getSuperRegionName() const { return superRegionName; }
-	[[nodiscard]] const std::optional<std::string>& getProvinceType() const { return provinceType; }
+	[[nodiscard]] const std::set<std::string>& getProvinceTypes() const { return provinceTypes; }
 	[[nodiscard]] bool isWater() const;
 	[[nodiscard]] bool isImpassable() const;
 
 	void setAreaName(std::string name);
 	void setRegionName(std::string name);
 	void setSuperRegionName(std::string name);
-	void setProvinceType(std::string name);
+	void addProvinceType(std::string name);
 
 	bool operator==(const Province& rhs) const;
 	bool operator==(const Pixel& rhs) const;
@@ -42,7 +43,7 @@ class Province final
 	std::optional<std::string> areaName;
 	std::optional<std::string> regionName;
 	std::optional<std::string> superRegionName;
-	std::optional<std::string> provinceType;
+	std::set<std::string> provinceTypes;
 };
 
 #endif // PROVINCE_H


### PR DESCRIPTION
1. Support for a province having multiple types. I've checked and impassable sea provinces on the map borders are both `sea_zones` and `wasteland`:
![obraz](https://github.com/user-attachments/assets/30421ce0-d608-4a74-ad95-53ac16aa21c5)

2. Support for I:R definition.csv defining province 0 in the second line, not the first.
It starts like this: 
```
#Province id 0 is ignored, hard coded.
0;0;0;0;;x;;;;;;;;;;;;;;;;;,
```
Previously, the ProvinceMapper would skip the first line, but then load the province 0 from the second line.
Which is bad, because province 3222 has the same color (0, 0, 0):
![obraz](https://github.com/user-attachments/assets/0581ada2-5ee3-4296-8e48-1321d00f7c7b)
Which resulted in a large chunk of Africa being recognized as province 0 💀:
![obraz](https://github.com/user-attachments/assets/5049c616-1d49-4327-9409-a6baec38518c)
Now it works correctly:
![obraz](https://github.com/user-attachments/assets/0645ee18-eb5f-4031-9907-74dc279b137f)

