### PR TITLE
Ditch adjacencies checkmark

### DIFF
--- a/ProvinceMapper.vcxproj
+++ b/ProvinceMapper.vcxproj
@@ -7,6 +7,13 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="ProvinceMapper\Source\Definitions\EU5Definitions.cpp" />
+    <ClCompile Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5Area.cpp" />
+    <ClCompile Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5Continent.cpp" />
+    <ClCompile Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5Province.cpp" />
+    <ClCompile Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5Region.cpp" />
+    <ClCompile Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5RegionManager.cpp" />
+    <ClCompile Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5SuperRegion.cpp" />
     <ClCompile Include="ProvinceMapper\Source\Frames\Search\SearchFrame.cpp" />
     <ClCompile Include="ProvinceMapper\Source\Frames\Search\SearchTab.cpp" />
     <ClCompile Include="ProvinceMapper\Source\LinkMapper\Automapper.cpp" />
@@ -65,6 +72,13 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="ProvinceMapper\Source\Definitions\EU5Definitions.h" />
+    <ClInclude Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5Area.h" />
+    <ClInclude Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5Continent.h" />
+    <ClInclude Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5Province.h" />
+    <ClInclude Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5Region.h" />
+    <ClInclude Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5RegionManager.h" />
+    <ClInclude Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5SuperRegion.h" />
     <ClInclude Include="ProvinceMapper\Source\Frames\Search\SearchFrame.h" />
     <ClInclude Include="ProvinceMapper\Source\Frames\Search\SearchTab.h" />
     <ClInclude Include="ProvinceMapper\Source\LinkMapper\Automapper.h" />

--- a/ProvinceMapper.vcxproj.filters
+++ b/ProvinceMapper.vcxproj.filters
@@ -52,6 +52,9 @@
     <Filter Include="ProvinceMapper\Definitions\Vic3Regions">
       <UniqueIdentifier>{b892f8a5-fac3-452c-9543-d7e7240a6026}</UniqueIdentifier>
     </Filter>
+    <Filter Include="ProvinceMapper\Definitions\EU5Regions">
+      <UniqueIdentifier>{ef028f55-f639-4a9b-a126-5aacd0000724}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="commonItems\ParserHelpers.cpp">
@@ -198,6 +201,27 @@
     <ClCompile Include="ProvinceMapper\Source\LinkMapper\Automapper.cpp" />
     <ClCompile Include="ProvinceMapper\Source\Frames\Search\SearchFrame.cpp" />
     <ClCompile Include="ProvinceMapper\Source\Frames\Search\SearchTab.cpp" />
+    <ClCompile Include="ProvinceMapper\Source\Definitions\EU5Definitions.cpp">
+      <Filter>ProvinceMapper\Definitions</Filter>
+    </ClCompile>
+    <ClCompile Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5RegionManager.cpp">
+      <Filter>ProvinceMapper\Definitions\EU5Regions</Filter>
+    </ClCompile>
+    <ClCompile Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5Area.cpp">
+      <Filter>ProvinceMapper\Definitions\EU5Regions</Filter>
+    </ClCompile>
+    <ClCompile Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5Continent.cpp">
+      <Filter>ProvinceMapper\Definitions\EU5Regions</Filter>
+    </ClCompile>
+    <ClCompile Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5Province.cpp">
+      <Filter>ProvinceMapper\Definitions\EU5Regions</Filter>
+    </ClCompile>
+    <ClCompile Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5Region.cpp">
+      <Filter>ProvinceMapper\Definitions\EU5Regions</Filter>
+    </ClCompile>
+    <ClCompile Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5SuperRegion.cpp">
+      <Filter>ProvinceMapper\Definitions\EU5Regions</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="commonItems\ParserHelpers.h">
@@ -339,6 +363,27 @@
     <ClInclude Include="ProvinceMapper\Source\LinkMapper\Automapper.h" />
     <ClInclude Include="ProvinceMapper\Source\Frames\Search\SearchFrame.h" />
     <ClInclude Include="ProvinceMapper\Source\Frames\Search\SearchTab.h" />
+    <ClInclude Include="ProvinceMapper\Source\Definitions\EU5Definitions.h">
+      <Filter>ProvinceMapper\Definitions</Filter>
+    </ClInclude>
+    <ClInclude Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5RegionManager.h">
+      <Filter>ProvinceMapper\Definitions\EU5Regions</Filter>
+    </ClInclude>
+    <ClInclude Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5Area.h">
+      <Filter>ProvinceMapper\Definitions\EU5Regions</Filter>
+    </ClInclude>
+    <ClInclude Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5Continent.h">
+      <Filter>ProvinceMapper\Definitions\EU5Regions</Filter>
+    </ClInclude>
+    <ClInclude Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5Province.h">
+      <Filter>ProvinceMapper\Definitions\EU5Regions</Filter>
+    </ClInclude>
+    <ClInclude Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5Region.h">
+      <Filter>ProvinceMapper\Definitions\EU5Regions</Filter>
+    </ClInclude>
+    <ClInclude Include="ProvinceMapper\Source\Definitions\EU5Regions\EU5SuperRegion.h">
+      <Filter>ProvinceMapper\Definitions\EU5Regions</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="ProvinceMapper\Resources\converter.ico">

--- a/ProvinceMapper/Source/Configuration/Configuration.cpp
+++ b/ProvinceMapper/Source/Configuration/Configuration.cpp
@@ -27,6 +27,9 @@ void Configuration::registerKeys()
 	registerKeyword("reverseTarget", [this](std::istream& theStream) {
 		reverseTarget = commonItems::getString(theStream) == "true";
 	});
+	registerKeyword("ditchAdjacencies", [this](std::istream& theStream) {
+		ditchAdjacencies = commonItems::getString(theStream) == "true";
+	});
 	registerKeyword("imageFramePos", [this](std::istream& theStream) {
 		const auto& theInts = commonItems::getInts(theStream);
 		if (theInts.size() == 2)
@@ -106,6 +109,8 @@ std::ostream& operator<<(std::ostream& output, const Configuration& configuratio
 		output << "targetDir = \"" << configuration.targetDir->string() << "\"\n";
 	if (configuration.reverseTarget)
 		output << "reverseTarget = true\n";
+	if (configuration.ditchAdjacencies)
+		output << "ditchAdjacencies = true\n";
 	if (configuration.sourceToken)
 		output << "sourceToken = \"" << *configuration.sourceToken << "\"\n";
 	if (configuration.targetToken)

--- a/ProvinceMapper/Source/Configuration/Configuration.h
+++ b/ProvinceMapper/Source/Configuration/Configuration.h
@@ -26,6 +26,7 @@ class Configuration: commonItems::parser
 	[[nodiscard]] const auto& getLinkFile() const { return linkFile; }
 	[[nodiscard]] auto isSourceReversed() const { return reverseSource; }
 	[[nodiscard]] auto isTargetReversed() const { return reverseTarget; }
+	[[nodiscard]] auto isDitchAdjacencies() const { return ditchAdjacencies; }
 	[[nodiscard]] const auto& getImageFramePos() const { return imageFramePos; }
 	[[nodiscard]] const auto& getImageFrameSize() const { return imageFrameSize; }
 	[[nodiscard]] auto isImageFrameMaximized() const { return imageFrameMaximized; }
@@ -50,6 +51,7 @@ class Configuration: commonItems::parser
 	void setLinkFile(const std::filesystem::path& file) { linkFile = file; }
 	void setSourceReversed(const bool reversed) { reverseSource = reversed; }
 	void setTargetReversed(const bool reversed) { reverseTarget = reversed; }
+	void setDitchAdjacencies(const bool ditch) { ditchAdjacencies = ditch; }
 	void setImageFramePos(const int x, const int y) { imageFramePos = Rect(x, y); }
 	void setImageFrameSize(const int x, const int y) { imageFrameSize = Rect(x, y); }
 	void setImageFrameMaximized(const bool on) { imageFrameMaximized = on; }
@@ -77,6 +79,7 @@ class Configuration: commonItems::parser
 
 	bool reverseSource = false;
 	bool reverseTarget = false;
+	bool ditchAdjacencies = false;
 	std::optional<std::filesystem::path> sourceDir;
 	std::optional<std::filesystem::path> targetDir;
 	std::optional<std::string> sourceToken;

--- a/ProvinceMapper/Source/Definitions/DefinitionsInterface.h
+++ b/ProvinceMapper/Source/Definitions/DefinitionsInterface.h
@@ -31,7 +31,7 @@ class DefinitionsInterface
 	[[nodiscard]] virtual std::shared_ptr<Province> getProvinceForID(const std::string& ID) = 0;
 
   protected:
-	std::map<std::string, std::shared_ptr<Province>> provinces;		// ID, province
+	std::map<std::string, std::shared_ptr<Province>> provinces;		// ID, province (or location for eu5)
 	std::map<unsigned int, std::shared_ptr<Province>> chromaCache; // color, province
 };
 

--- a/ProvinceMapper/Source/Definitions/EU5Definitions.cpp
+++ b/ProvinceMapper/Source/Definitions/EU5Definitions.cpp
@@ -83,7 +83,6 @@ void EU5Definitions::filloutProvinceDetails(const LocalizationMapper& localizati
 			auto locName = localizationMapper.getLocForSourceKey(provinceName);
 			if (locName && !locName->empty())
 			{
-				Log(LogLevel::Debug) << "for sourcename for " << provinceName << " : " << *locName;
 				province->locName = *locName;
 			}
 		}

--- a/ProvinceMapper/Source/Definitions/EU5Definitions.cpp
+++ b/ProvinceMapper/Source/Definitions/EU5Definitions.cpp
@@ -1,0 +1,322 @@
+#include "EU5Definitions.h"
+#include "Provinces/Pixel.h"
+#include "Provinces/Province.h"
+#include <CommonRegexes.h>
+#include <OSCompatibilityLayer.h>
+#include <ParserHelpers.h>
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+namespace fs = std::filesystem;
+
+namespace
+{
+std::tuple<int, int, int> breakDownChroma(const std::string& theChroma)
+{
+	const auto r = std::stoi(theChroma.substr(0, 2), nullptr, 16);
+	const auto g = std::stoi(theChroma.substr(2, 2), nullptr, 16);
+	const auto b = std::stoi(theChroma.substr(4, 2), nullptr, 16);
+
+	return {r, g, b};
+}
+
+std::string tolower(std::string str)
+{
+	std::transform(str.begin(), str.end(), str.begin(), [](unsigned char c) {
+		return std::tolower(c);
+	});
+	return str;
+}
+
+} // namespace
+
+void EU5Definitions::loadDefinitions(const fs::path& mapDataPath, const LocalizationMapper& localizationMapper, LocalizationMapper::LocType locType)
+{
+	if (!commonItems::DoesFileExist(mapDataPath / "named_locations/00_default.txt"))
+		throw std::runtime_error("Named Locations file cannot be found!");
+
+	if (commonItems::DoesFileExist(mapDataPath / "definitions.txt"))
+		eu5RegionManager.loadContinents(mapDataPath);
+
+	// A bit of misnomer. Definitions file is actually the named_locations/00_default.txt one.
+	// definitions.txt is actually hierarchy file, akin to eu4's area.txt, regions.txt etc.
+
+	registerKeys();
+	defParser.parseFile(mapDataPath / "named_locations/00_default.txt");
+	defParser.clearRegisteredKeywords();
+
+	filloutProvinceDetails(localizationMapper, locType);
+
+	tryToLoadProvinceTypes(mapDataPath);
+}
+
+void EU5Definitions::registerKeys()
+{
+	defParser.registerRegex(commonItems::catchallRegex, [this](const std::string& locationName, std::istream& theStream) {
+		auto chroma = commonItems::getString(theStream);
+
+		// First deal with shit.
+		if (chroma.size() > 6)
+		{
+			chroma = chroma.substr(0, 6);
+		}
+
+		if (chroma.size() != 6)
+		{
+			chroma.insert(0, 6 - chroma.size(), '0');
+		}
+
+		// Chroma needs to be broken into rgb ints.
+		const auto [r, g, b] = breakDownChroma(chroma);
+		auto province = std::make_shared<Province>(locationName, r, g, b, locationName); // id is the same as the name.
+		provinces.emplace(locationName, province);
+	});
+}
+
+void EU5Definitions::filloutProvinceDetails(const LocalizationMapper& localizationMapper, LocalizationMapper::LocType locType)
+{
+	for (const auto& [provinceName, province]: provinces)
+	{
+		// locs
+		if (locType == LocalizationMapper::LocType::SOURCE)
+		{
+			auto locName = localizationMapper.getLocForSourceKey(provinceName);
+			if (locName && !locName->empty())
+			{
+				Log(LogLevel::Debug) << "for sourcename for " << provinceName << " : " << *locName;
+				province->locName = *locName;
+			}
+		}
+		else
+		{
+			auto locName = localizationMapper.getLocForTargetKey(provinceName);
+			if (locName && !locName->empty())
+				province->locName = *locName;
+		}
+
+		// regionals
+		if (locType == LocalizationMapper::LocType::SOURCE)
+		{
+			if (const auto& regName = eu5RegionManager.getParentProvinceName(provinceName); regName)
+			{
+				const auto& locName = localizationMapper.getLocForSourceKey(*regName);
+				if (locName && !locName->empty())
+					province->setProvinceName(*locName);
+				else
+					province->setProvinceName(*regName);
+			}
+			if (const auto& regName = eu5RegionManager.getParentAreaName(provinceName); regName)
+			{
+				const auto& locName = localizationMapper.getLocForSourceKey(*regName);
+				if (locName && !locName->empty())
+					province->setAreaName(*locName);
+				else
+					province->setAreaName(*regName);
+			}
+			if (const auto& regName = eu5RegionManager.getParentRegionName(provinceName); regName)
+			{
+				const auto& locName = localizationMapper.getLocForSourceKey(*regName);
+				if (locName && !locName->empty())
+					province->setRegionName(*locName);
+				else
+					province->setRegionName(*regName);
+			}
+			if (const auto& regName = eu5RegionManager.getParentSuperRegionName(provinceName); regName)
+			{
+				const auto& locName = localizationMapper.getLocForSourceKey(*regName);
+				if (locName && !locName->empty())
+					province->setSuperRegionName(*locName);
+				else
+					province->setSuperRegionName(*regName);
+			}
+			if (const auto& regName = eu5RegionManager.getParentContinentName(provinceName); regName)
+			{
+				const auto& locName = localizationMapper.getLocForSourceKey(*regName);
+				if (locName && !locName->empty())
+					province->setContinentName(*locName);
+				else
+					province->setContinentName(*regName);
+			}
+		}
+		else
+		{
+			if (const auto& regName = eu5RegionManager.getParentProvinceName(provinceName); regName)
+			{
+				const auto& locName = localizationMapper.getLocForTargetKey(*regName);
+				if (locName && !locName->empty())
+					province->setProvinceName(*locName);
+				else
+					province->setProvinceName(*regName);
+			}
+			if (const auto& regName = eu5RegionManager.getParentAreaName(provinceName); regName)
+			{
+				const auto& locName = localizationMapper.getLocForTargetKey(*regName);
+				if (locName && !locName->empty())
+					province->setAreaName(*locName);
+				else
+					province->setAreaName(*regName);
+			}
+			if (const auto& regName = eu5RegionManager.getParentRegionName(provinceName); regName)
+			{
+				const auto& locName = localizationMapper.getLocForTargetKey(*regName);
+				if (locName && !locName->empty())
+					province->setRegionName(*locName);
+				else
+					province->setRegionName(*regName);
+			}
+			if (const auto& regName = eu5RegionManager.getParentSuperRegionName(provinceName); regName)
+			{
+				const auto& locName = localizationMapper.getLocForTargetKey(*regName);
+				if (locName && !locName->empty())
+					province->setSuperRegionName(*locName);
+				else
+					province->setSuperRegionName(*regName);
+			}
+			if (const auto& regName = eu5RegionManager.getParentContinentName(provinceName); regName)
+			{
+				const auto& locName = localizationMapper.getLocForTargetKey(*regName);
+				if (locName && !locName->empty())
+					province->setContinentName(*locName);
+				else
+					province->setContinentName(*regName);
+			}
+		}
+
+		// chromaCache
+		chromaCache.insert(std::pair(pixelPack(province->r, province->g, province->b), province));
+	}
+}
+
+void EU5Definitions::registerPixel(int x, int y, unsigned char r, unsigned char g, unsigned char b)
+{
+	Pixel pixel(x, y, r, g, b);
+	const auto& chromaItr = chromaCache.find(pixelPack(r, g, b));
+	if (chromaItr != chromaCache.end())
+		chromaItr->second->innerPixels.emplace_back(pixel);
+}
+
+void EU5Definitions::registerBorderPixel(int x, int y, unsigned char r, unsigned char g, unsigned char b)
+{
+	Pixel pixel(x, y, r, g, b);
+	const auto& chromaItr = chromaCache.find(pixelPack(r, g, b));
+	if (chromaItr != chromaCache.end())
+		chromaItr->second->borderPixels.emplace_back(pixel);
+}
+
+std::optional<std::string> EU5Definitions::getNameForChroma(const unsigned int chroma)
+{
+	if (const auto& chromaCacheItr = chromaCache.find(chroma); chromaCacheItr != chromaCache.end())
+		if (chromaCacheItr->second)
+			return chromaCacheItr->second->bespokeName();
+	return std::nullopt;
+}
+
+std::optional<std::string> EU5Definitions::getMiscForChroma(const unsigned int chroma)
+{
+	if (const auto& chromaCacheItr = chromaCache.find(chroma); chromaCacheItr != chromaCache.end())
+		if (chromaCacheItr->second)
+			return chromaCacheItr->second->miscName();
+	return std::nullopt;
+}
+
+std::optional<std::string> EU5Definitions::getIDForChroma(const unsigned int chroma)
+{
+	if (const auto& chromaCacheItr = chromaCache.find(chroma); chromaCacheItr != chromaCache.end())
+		if (chromaCacheItr->second)
+			return chromaCacheItr->second->ID;
+	return std::nullopt;
+}
+
+std::shared_ptr<Province> EU5Definitions::getProvinceForChroma(const unsigned int chroma)
+{
+	if (const auto& chromaCacheItr = chromaCache.find(chroma); chromaCacheItr != chromaCache.end())
+		if (chromaCacheItr->second)
+			return chromaCacheItr->second;
+	return nullptr;
+}
+
+std::shared_ptr<Province> EU5Definitions::getProvinceForID(const std::string& ID)
+{
+	if (const auto& provinceItr = provinces.find(ID); provinceItr != provinces.end())
+		if (provinceItr->second)
+			return provinceItr->second;
+	return nullptr;
+}
+
+void EU5Definitions::loadLocalizations(const LocalizationMapper& localizationMapper, LocalizationMapper::LocType locType)
+{
+	for (const auto& [id, province]: provinces)
+	{
+		if (locType == LocalizationMapper::LocType::SOURCE && localizationMapper.getLocForSourceKey(id))
+			province->locName = *localizationMapper.getLocForSourceKey(id);
+		if (locType == LocalizationMapper::LocType::TARGET && localizationMapper.getLocForTargetKey(id))
+			province->locName = *localizationMapper.getLocForTargetKey(id);
+	}
+}
+
+void EU5Definitions::registerNeighbor(unsigned int provinceChroma, unsigned int neighborChroma)
+{
+	if (!neighborChromas.contains(provinceChroma))
+		neighborChromas.emplace(provinceChroma, std::set<unsigned int>{});
+	neighborChromas.at(provinceChroma).emplace(neighborChroma);
+}
+
+std::map<unsigned int, std::set<unsigned int>> EU5Definitions::getNeighborChromas() const
+{
+	return neighborChromas;
+}
+
+void EU5Definitions::ditchAdjacencies(const fs::path& fileName)
+{
+	std::map<std::string, std::set<std::string>> adjacencies;
+	for (const auto& [sourceChroma, targetChromas]: neighborChromas)
+	{
+		if (const auto& sourceProvince = getIDForChroma(sourceChroma); sourceProvince)
+		{
+			adjacencies.emplace(*sourceProvince, std::set<std::string>{});
+			for (const auto& targetChroma: targetChromas)
+			{
+				if (const auto& targetProvince = getIDForChroma(targetChroma); targetProvince)
+					adjacencies.at(*sourceProvince).emplace(*targetProvince);
+			}
+		}
+	}
+	std::ofstream adjacenciesFile(fileName);
+	for (const auto& [sourceProvince, targetProvinces]: adjacencies)
+	{
+		if (targetProvinces.empty())
+			continue;
+		adjacenciesFile << sourceProvince << " = { ";
+		for (const auto& targetProvince: targetProvinces)
+			adjacenciesFile << targetProvince << " ";
+		adjacenciesFile << "}\n";
+	}
+	adjacenciesFile.close();
+}
+
+void EU5Definitions::tryToLoadProvinceTypes(const fs::path& mapDataPath)
+{
+	const fs::path filePath = mapDataPath / "default.map";
+	if (!commonItems::DoesFileExist(filePath))
+	{
+		return;
+	}
+
+	auto parser = commonItems::parser();
+	const std::string provinceTypesRegex =
+		 "sea_zones|wasteland|impassable_terrain|uninhabitable|river_provinces|lakes|LAKES|impassable_mountains|impassable_seas|non_ownable";
+
+	parser.registerRegex(provinceTypesRegex, [&](const std::string& provinceType, std::istream& stream) {
+		std::string lowerCaseProvinceType = tolower(provinceType);
+
+		auto provIds = commonItems::getStrings(stream);
+		for (auto& id: provIds)
+		{
+			if (provinces.contains(id) && provinces.at(id))
+				provinces[id]->addProvinceType(lowerCaseProvinceType);
+		}
+	});
+
+	parser.IgnoreUnregisteredItems();
+	parser.parseFile(filePath);
+}

--- a/ProvinceMapper/Source/Definitions/EU5Definitions.h
+++ b/ProvinceMapper/Source/Definitions/EU5Definitions.h
@@ -1,0 +1,37 @@
+#ifndef EU5_DEFINITIONS_H
+#define EU5_DEFINITIONS_H
+#include "DefinitionsInterface.h"
+#include "EU5Regions/EU5RegionManager.h"
+
+class Province;
+class EU5Definitions: public DefinitionsInterface
+{
+  public:
+	void loadDefinitions(const std::filesystem::path& fileName, const LocalizationMapper& localizationMapper, LocalizationMapper::LocType locType);
+	void loadLocalizations(const LocalizationMapper& localizationMapper, LocalizationMapper::LocType locType) override;
+	void loadVic3Regions(const std::filesystem::path& folderPath) override {}
+
+	void registerPixel(int x, int y, unsigned char r, unsigned char g, unsigned char b) override;
+	void registerBorderPixel(int x, int y, unsigned char r, unsigned char g, unsigned char b) override;
+	void registerNeighbor(unsigned int provinceChroma, unsigned int neighborChroma) override;
+	void ditchAdjacencies(const std::filesystem::path& fileName) override;
+
+	[[nodiscard]] std::optional<std::string> getNameForChroma(unsigned int chroma) override;
+	[[nodiscard]] std::optional<std::string> getMiscForChroma(unsigned int chroma) override;
+	[[nodiscard]] std::optional<std::string> getIDForChroma(unsigned int chroma) override;
+	[[nodiscard]] std::shared_ptr<Province> getProvinceForChroma(unsigned int chroma) override;
+	[[nodiscard]] std::shared_ptr<Province> getProvinceForID(const std::string& ID) override;
+	[[nodiscard]] std::map<unsigned int, std::set<unsigned int>> getNeighborChromas() const override;
+
+  private:
+	void registerKeys();
+	void filloutProvinceDetails(const LocalizationMapper& localizationMapper, LocalizationMapper::LocType locType);
+	void tryToLoadProvinceTypes(const std::filesystem::path& mapDataPath);
+
+	commonItems::parser defParser;
+
+	EU5::EU5RegionManager eu5RegionManager;
+	std::map<unsigned int, std::set<unsigned int>> neighborChromas; // chroma-> neighbor chromas
+};
+
+#endif // DEFINITIONS_H

--- a/ProvinceMapper/Source/Definitions/EU5Regions/EU5Area.cpp
+++ b/ProvinceMapper/Source/Definitions/EU5Regions/EU5Area.cpp
@@ -1,0 +1,28 @@
+#include "EU5Area.h"
+#include <CommonRegexes.h>
+#include <ParserHelpers.h>
+#include <ranges>
+
+EU5::EU5Area::EU5Area(std::istream& theStream)
+{
+	registerKeys();
+	parseStream(theStream);
+	clearRegisteredKeywords();
+}
+
+void EU5::EU5Area::registerKeys()
+{
+	registerRegex(commonItems::catchallRegex, [this](const std::string& provinceName, std::istream& theStream) {
+		const auto locationsList = commonItems::getStrings(theStream);
+		auto province = std::make_shared<EU5Province>(locationsList);
+		provinces.emplace(provinceName, province);
+	});
+}
+
+bool EU5::EU5Area::areaContainsLocation(const std::string& location) const
+{
+	for (const auto& province: provinces | std::views::values)
+		if (province->provinceContainsLocation(location))
+			return true;
+	return false;
+}

--- a/ProvinceMapper/Source/Definitions/EU5Regions/EU5Area.h
+++ b/ProvinceMapper/Source/Definitions/EU5Regions/EU5Area.h
@@ -1,0 +1,26 @@
+#ifndef EU5_AREA_H
+#define EU5_AREA_H
+#include "EU5Province.h"
+#include <Parser.h>
+
+namespace EU5
+{
+class EU5Area: commonItems::parser
+{
+  public:
+	EU5Area() = default;
+	explicit EU5Area(std::istream& theStream);
+
+	[[nodiscard]] const auto& getProvinces() const { return provinces; }
+	[[nodiscard]] bool areaContainsLocation(const std::string& location) const;
+
+	void linkProvince(const std::pair<std::string, std::shared_ptr<EU5Province>>& theProvince) { provinces.at(theProvince.first) = theProvince.second; }
+
+  private:
+	void registerKeys();
+
+	std::map<std::string, std::shared_ptr<EU5Province>> provinces;
+};
+} // namespace EU5
+
+#endif // EU5_AREA_H

--- a/ProvinceMapper/Source/Definitions/EU5Regions/EU5Continent.cpp
+++ b/ProvinceMapper/Source/Definitions/EU5Regions/EU5Continent.cpp
@@ -1,0 +1,28 @@
+#include "EU5Continent.h"
+#include <CommonRegexes.h>
+#include <ParserHelpers.h>
+#include <ranges>
+
+EU5::EU5Continent::EU5Continent(std::istream& theStream)
+{
+	registerKeys();
+	parseStream(theStream);
+	clearRegisteredKeywords();
+}
+
+void EU5::EU5Continent::registerKeys()
+{
+	registerRegex(commonItems::catchallRegex, [this](const std::string& superRegionName, std::istream& theStream) {
+		auto superRegion = std::make_shared<EU5SuperRegion>(theStream);
+		superRegions.emplace(superRegionName, superRegion);
+	});
+	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
+}
+
+bool EU5::EU5Continent::continentContainsLocation(const std::string& location) const
+{
+	for (const auto& superRegion: superRegions | std::views::values)
+		if (superRegion->superRegionContainsLocation(location))
+			return true;
+	return false;
+}

--- a/ProvinceMapper/Source/Definitions/EU5Regions/EU5Continent.h
+++ b/ProvinceMapper/Source/Definitions/EU5Regions/EU5Continent.h
@@ -1,0 +1,24 @@
+#ifndef EU5_CONTINENT_H
+#define EU5_CONTINENT_H
+#include "EU5SuperRegion.h"
+#include <Parser.h>
+
+namespace EU5
+{
+class EU5Continent: commonItems::parser
+{
+  public:
+	EU5Continent() = default;
+	explicit EU5Continent(std::istream& theStream);
+
+	[[nodiscard]] const auto& getSuperRegions() const { return superRegions; }
+	[[nodiscard]] bool continentContainsLocation(const std::string& location) const;
+
+  private:
+	void registerKeys();
+
+	std::map<std::string, std::shared_ptr<EU5SuperRegion>> superRegions;
+};
+} // namespace EU5
+
+#endif // EU5_CONTINENT_H

--- a/ProvinceMapper/Source/Definitions/EU5Regions/EU5Province.cpp
+++ b/ProvinceMapper/Source/Definitions/EU5Regions/EU5Province.cpp
@@ -1,0 +1,12 @@
+#include "EU5Province.h"
+
+EU5::EU5Province::EU5Province(const std::vector<std::string>& theLocations)
+{
+	for (const auto& location: theLocations)
+		locations.emplace(location);
+}
+
+bool EU5::EU5Province::provinceContainsLocation(const std::string& location) const
+{
+	return locations.contains(location);
+}

--- a/ProvinceMapper/Source/Definitions/EU5Regions/EU5Province.h
+++ b/ProvinceMapper/Source/Definitions/EU5Regions/EU5Province.h
@@ -1,0 +1,22 @@
+#ifndef EU5_PROVINCE_H
+#define EU5_PROVINCE_H
+#include <Parser.h>
+#include <set>
+
+namespace EU5
+{
+class EU5Province
+{
+  public:
+	EU5Province() = default;
+	explicit EU5Province(const std::vector<std::string>& theLocations);
+
+	[[nodiscard]] const auto& getLocations() const { return locations; }
+	[[nodiscard]] bool provinceContainsLocation(const std::string& location) const;
+
+  private:
+	std::set<std::string> locations;
+};
+} // namespace EU5
+
+#endif // EU5_PROVINCE_H

--- a/ProvinceMapper/Source/Definitions/EU5Regions/EU5Region.cpp
+++ b/ProvinceMapper/Source/Definitions/EU5Regions/EU5Region.cpp
@@ -1,0 +1,28 @@
+#include "EU5Region.h"
+#include <CommonRegexes.h>
+#include <ParserHelpers.h>
+#include <ranges>
+
+EU5::EU5Region::EU5Region(std::istream& theStream)
+{
+	registerKeys();
+	parseStream(theStream);
+	clearRegisteredKeywords();
+}
+
+void EU5::EU5Region::registerKeys()
+{
+	registerRegex(commonItems::catchallRegex, [this](const std::string& areaName, std::istream& theStream) {
+		auto area = std::make_shared<EU5Area>(theStream);
+		areas.emplace(areaName, area);
+	});
+	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
+}
+
+bool EU5::EU5Region::regionContainsLocation(const std::string& location) const
+{
+	for (const auto& area: areas | std::views::values)
+		if (area->areaContainsLocation(location))
+			return true;
+	return false;
+}

--- a/ProvinceMapper/Source/Definitions/EU5Regions/EU5Region.h
+++ b/ProvinceMapper/Source/Definitions/EU5Regions/EU5Region.h
@@ -1,0 +1,24 @@
+#ifndef EU5_REGION_H
+#define EU5_REGION_H
+#include "EU5Area.h"
+#include <Parser.h>
+
+namespace EU5
+{
+class EU5Region: commonItems::parser
+{
+  public:
+	EU5Region() = default;
+	explicit EU5Region(std::istream& theStream);
+
+	[[nodiscard]] const auto& getAreas() const { return areas; }
+	[[nodiscard]] bool regionContainsLocation(const std::string& location) const;
+
+  private:
+	void registerKeys();
+
+	std::map<std::string, std::shared_ptr<EU5Area>> areas;
+};
+} // namespace EU5
+
+#endif // EU5_REGION_H

--- a/ProvinceMapper/Source/Definitions/EU5Regions/EU5RegionManager.cpp
+++ b/ProvinceMapper/Source/Definitions/EU5Regions/EU5RegionManager.cpp
@@ -14,15 +14,11 @@ void EU5::EU5RegionManager::loadContinents(const std::filesystem::path& EU5Path)
 
 	auto definitionFile = EU5Path / "definitions.txt";
 
-	std::ifstream defsStream(definitionFile);
-	if (!defsStream.is_open())
-		throw std::runtime_error("Could not open definitions.txt!");
 	registerKeys();
-	parseStream(defsStream);
+	parseFile(definitionFile);
 	clearRegisteredKeywords();
-	defsStream.close();
 
-	Log(LogLevel::Info) << "EU4 Region manager : " << continents.size() << " continents.";
+	Log(LogLevel::Info) << "EU5 Region manager : " << continents.size() << " continents.";
 }
 
 void EU5::EU5RegionManager::registerKeys()

--- a/ProvinceMapper/Source/Definitions/EU5Regions/EU5RegionManager.cpp
+++ b/ProvinceMapper/Source/Definitions/EU5Regions/EU5RegionManager.cpp
@@ -1,0 +1,129 @@
+#include "EU5RegionManager.h"
+#include "CommonRegexes.h"
+#include <Log.h>
+#include <OSCompatibilityLayer.h>
+#include <ParserHelpers.h>
+#include <filesystem>
+#include <fstream>
+#include <ranges>
+namespace fs = std::filesystem;
+
+void EU5::EU5RegionManager::loadContinents(const std::filesystem::path& EU5Path)
+{
+	Log(LogLevel::Info) << "EU5 Region manager online.";
+
+	auto definitionFile = EU5Path / "definitions.txt";
+
+	std::ifstream defsStream(definitionFile);
+	if (!defsStream.is_open())
+		throw std::runtime_error("Could not open definitions.txt!");
+	registerKeys();
+	parseStream(defsStream);
+	clearRegisteredKeywords();
+	defsStream.close();
+
+	Log(LogLevel::Info) << "EU4 Region manager : " << continents.size() << " continents.";
+}
+
+void EU5::EU5RegionManager::registerKeys()
+{
+	registerRegex(commonItems::catchallRegex, [this](const std::string& continentName, std::istream& theStream) {
+		auto continent = std::make_shared<EU5Continent>(theStream);
+		continents.emplace(continentName, continent);
+	});
+}
+
+std::optional<std::string> EU5::EU5RegionManager::getParentProvinceName(const std::string& location) const
+{
+	for (const auto& continent: continents | std::views::values)
+		if (continent->continentContainsLocation(location))
+		{
+			for (const auto& superRegion: continent->getSuperRegions() | std::views::values)
+				if (superRegion->superRegionContainsLocation(location))
+				{
+					for (const auto& region: superRegion->getRegions() | std::views::values)
+						if (region->regionContainsLocation(location))
+						{
+							for (const auto& area: region->getAreas() | std::views::values)
+								if (area->areaContainsLocation(location))
+								{
+									for (const auto& [provinceName, province]: area->getProvinces())
+										if (province->provinceContainsLocation(location))
+										{
+											return provinceName;
+										}
+								}
+						}
+				}
+		}
+
+	return std::nullopt;
+}
+
+std::optional<std::string> EU5::EU5RegionManager::getParentAreaName(const std::string& location) const
+{
+	for (const auto& continent: continents | std::views::values)
+		if (continent->continentContainsLocation(location))
+		{
+			for (const auto& superRegion: continent->getSuperRegions() | std::views::values)
+				if (superRegion->superRegionContainsLocation(location))
+				{
+					for (const auto& region: superRegion->getRegions() | std::views::values)
+						if (region->regionContainsLocation(location))
+						{
+							for (const auto& [areaName, area]: region->getAreas())
+								if (area->areaContainsLocation(location))
+								{
+									return areaName;
+								}
+						}
+				}
+		}
+
+	return std::nullopt;
+}
+
+std::optional<std::string> EU5::EU5RegionManager::getParentRegionName(const std::string& location) const
+{
+	for (const auto& continent: continents | std::views::values)
+		if (continent->continentContainsLocation(location))
+		{
+			for (const auto& superRegion: continent->getSuperRegions() | std::views::values)
+				if (superRegion->superRegionContainsLocation(location))
+				{
+					for (const auto& [regionName, region]: superRegion->getRegions())
+						if (region->regionContainsLocation(location))
+						{
+							return regionName;
+						}
+				}
+		}
+
+	return std::nullopt;
+}
+
+std::optional<std::string> EU5::EU5RegionManager::getParentSuperRegionName(const std::string& location) const
+{
+	for (const auto& continent: continents | std::views::values)
+		if (continent->continentContainsLocation(location))
+		{
+			for (const auto& [superRegionName, superRegion]: continent->getSuperRegions())
+				if (superRegion->superRegionContainsLocation(location))
+				{
+					return superRegionName;
+				}
+		}
+
+	return std::nullopt;
+}
+
+std::optional<std::string> EU5::EU5RegionManager::getParentContinentName(const std::string& location) const
+{
+	for (const auto& [continentName, continent]: continents)
+		if (continent->continentContainsLocation(location))
+		{
+			return continentName;
+		}
+
+	return std::nullopt;
+}

--- a/ProvinceMapper/Source/Definitions/EU5Regions/EU5RegionManager.h
+++ b/ProvinceMapper/Source/Definitions/EU5Regions/EU5RegionManager.h
@@ -1,0 +1,26 @@
+#ifndef EU5_REGIONMANAGER_H
+#define EU5_REGIONMANAGER_H
+#include "EU5Continent.h"
+#include <Parser.h>
+
+namespace EU5
+{
+class EU5RegionManager: commonItems::parser
+{
+  public:
+	void loadContinents(const std::filesystem::path& EU5Path);
+
+	[[nodiscard]] std::optional<std::string> getParentProvinceName(const std::string& location) const;
+	[[nodiscard]] std::optional<std::string> getParentAreaName(const std::string& location) const;
+	[[nodiscard]] std::optional<std::string> getParentRegionName(const std::string& location) const;
+	[[nodiscard]] std::optional<std::string> getParentSuperRegionName(const std::string& location) const;
+	[[nodiscard]] std::optional<std::string> getParentContinentName(const std::string& location) const;
+
+  private:
+	void registerKeys();
+
+	std::map<std::string, std::shared_ptr<EU5Continent>> continents;
+};
+} // namespace EU5
+
+#endif // EU5_REGIONMANAGER_H

--- a/ProvinceMapper/Source/Definitions/EU5Regions/EU5SuperRegion.cpp
+++ b/ProvinceMapper/Source/Definitions/EU5Regions/EU5SuperRegion.cpp
@@ -1,0 +1,26 @@
+#include "EU5SuperRegion.h"
+#include "CommonRegexes.h"
+#include <ranges>
+
+EU5::EU5SuperRegion::EU5SuperRegion(std::istream& theStream)
+{
+	registerKeys();
+	parseStream(theStream);
+	clearRegisteredKeywords();
+}
+
+void EU5::EU5SuperRegion::registerKeys()
+{
+	registerRegex(commonItems::catchallRegex, [this](const std::string& regionName, std::istream& theStream) {
+		auto region = std::make_shared<EU5Region>(theStream);
+		regions.emplace(regionName, region);
+	});
+}
+
+bool EU5::EU5SuperRegion::superRegionContainsLocation(const std::string& location) const
+{
+	for (const auto& region: regions | std::views::values)
+		if (region->regionContainsLocation(location))
+			return true;
+	return false;
+}

--- a/ProvinceMapper/Source/Definitions/EU5Regions/EU5SuperRegion.h
+++ b/ProvinceMapper/Source/Definitions/EU5Regions/EU5SuperRegion.h
@@ -1,0 +1,23 @@
+#ifndef EU5_SUPERREGION_H
+#define EU5_SUPERREGION_H
+#include "EU5Region.h"
+
+namespace EU5
+{
+class EU5SuperRegion: commonItems::parser
+{
+  public:
+	EU5SuperRegion() = default;
+	explicit EU5SuperRegion(std::istream& theStream);
+
+	[[nodiscard]] const auto& getRegions() const { return regions; }
+	[[nodiscard]] bool superRegionContainsLocation(const std::string& location) const;
+
+  private:
+	void registerKeys();
+
+	std::map<std::string, std::shared_ptr<EU5Region>> regions;
+};
+} // namespace EU5
+
+#endif // EU4_SUPERREGION_H

--- a/ProvinceMapper/Source/Frames/Images/ImageFrame.cpp
+++ b/ProvinceMapper/Source/Frames/Images/ImageFrame.cpp
@@ -75,6 +75,9 @@ ImageFrame::ImageFrame(wxWindow* parent,
 		statusBar->Show();
 
 	delaunayTriangulate();
+
+   auto dummyevt = wxCommandEvent();
+   onToggleBlack(dummyevt);
 }
 
 void ImageFrame::onScrollPaint(wxPaintEvent& event)

--- a/ProvinceMapper/Source/Frames/MainFrame.cpp
+++ b/ProvinceMapper/Source/Frames/MainFrame.cpp
@@ -1,6 +1,7 @@
 #include "MainFrame.h"
 #include "CommonFunctions.h"
 #include "Definitions/Definitions.h"
+#include "Definitions/EU5Definitions.h"
 #include "Definitions/Vic3Definitions.h"
 #include "Images/ImageCanvas.h"
 #include "Images/ImageFrame.h"
@@ -309,6 +310,13 @@ void MainFrame::initImageFrame()
 		sourceDefs = definitions;
 		Log(LogLevel::Info) << "Loaded " << sourceDefs->getProvinces().size() << " source provinces.";
 	}
+	if (commonItems::DoesFileExist(*configuration->getSourceDir() / "definitions.txt"))
+	{
+		auto definitions = std::make_shared<EU5Definitions>();
+		definitions->loadDefinitions(*configuration->getSourceDir(), localizationMapper, LocalizationMapper::LocType::SOURCE);
+		sourceDefs = definitions;
+		Log(LogLevel::Info) << "Loaded " << sourceDefs->getProvinces().size() << " source provinces.";
+	}
 	else
 	{
 		sourceDefs = std::make_shared<Vic3Definitions>();
@@ -322,6 +330,13 @@ void MainFrame::initImageFrame()
 		auto definitions = std::make_shared<Definitions>();
 		definitions->loadDefinitions(*configuration->getTargetDir(), localizationMapper, LocalizationMapper::LocType::TARGET);
 		targetDefs = definitions;
+		Log(LogLevel::Info) << "Loaded " << targetDefs->getProvinces().size() << " target provinces.";
+	}
+	if (commonItems::DoesFileExist(*configuration->getTargetDir() / "definitions.txt"))
+	{
+		auto definitions = std::make_shared<EU5Definitions>();
+		definitions->loadDefinitions(*configuration->getTargetDir(), localizationMapper, LocalizationMapper::LocType::TARGET);
+		sourceDefs = definitions;
 		Log(LogLevel::Info) << "Loaded " << targetDefs->getProvinces().size() << " target provinces.";
 	}
 	else
@@ -340,6 +355,8 @@ void MainFrame::initImageFrame()
 		sourceImg->LoadFile(configuration->getSourceDir()->string() + "/provinces.png");
 	else if (commonItems::DoesFileExist(*configuration->getSourceDir() / "provinces.bmp"))
 		sourceImg->LoadFile(configuration->getSourceDir()->string() + "/provinces.bmp");
+	else if (commonItems::DoesFileExist(*configuration->getSourceDir() / "locations.png"))
+		sourceImg->LoadFile(configuration->getSourceDir()->string() + "/locations.png");
 	if (commonItems::DoesFileExist(*configuration->getSourceDir() / "rivers.png"))
 		sourceRiversImg->LoadFile(configuration->getSourceDir()->string() + "/rivers.png");
 	else if (commonItems::DoesFileExist(*configuration->getSourceDir() / "rivers.bmp"))
@@ -351,6 +368,8 @@ void MainFrame::initImageFrame()
 		targetImg->LoadFile(configuration->getTargetDir()->string() + "/provinces.png");
 	else if (commonItems::DoesFileExist(*configuration->getTargetDir() / "provinces.bmp"))
 		targetImg->LoadFile(configuration->getTargetDir()->string() + "/provinces.bmp");
+	else if (commonItems::DoesFileExist(*configuration->getTargetDir() / "locations.png"))
+		targetImg->LoadFile(configuration->getTargetDir()->string() + "/locations.png");
 	if (commonItems::DoesFileExist(*configuration->getTargetDir() / "rivers.png"))
 		targetRiversImg->LoadFile(configuration->getTargetDir()->string() + "/rivers.png");
 	else if (commonItems::DoesFileExist(*configuration->getTargetDir() / "rivers.bmp"))
@@ -465,7 +484,8 @@ void MainFrame::onPathChanged(wxFileDirPickerEvent& evt)
 	// source path
 	if (evt.GetId() == 0)
 	{
-		if (validPath && (commonItems::DoesFileExist(result / "provinces.bmp") || commonItems::DoesFileExist(result / "provinces.png")))
+		if (validPath && (commonItems::DoesFileExist(result / "provinces.bmp") || commonItems::DoesFileExist(result / "provinces.png") ||
+									commonItems::DoesFileExist(result / "locations.png")))
 		{
 			sourceDirStatus->SetBackgroundColour(green);
 			sanity[0] = true;
@@ -480,7 +500,8 @@ void MainFrame::onPathChanged(wxFileDirPickerEvent& evt)
 	// target path
 	else if (evt.GetId() == 1)
 	{
-		if (validPath && (commonItems::DoesFileExist(result / "provinces.bmp") || commonItems::DoesFileExist(result / "provinces.png")))
+		if (validPath && (commonItems::DoesFileExist(result / "provinces.bmp") || commonItems::DoesFileExist(result / "provinces.png") ||
+									commonItems::DoesFileExist(result / "locations.png")))
 		{
 			targetDirStatus->SetBackgroundColour(green);
 			sanity[1] = true;

--- a/ProvinceMapper/Source/Frames/MainFrame.h
+++ b/ProvinceMapper/Source/Frames/MainFrame.h
@@ -28,7 +28,7 @@ class wxFileDirPickerEvent;
 enum class ImageTabSelector;
 class ImageFrame;
 class LinksFrame;
-class MainFrame final : public wxFrame
+class MainFrame final: public wxFrame
 {
   public:
 	MainFrame(const wxString& title, const wxPoint& pos, const wxSize& size);
@@ -111,6 +111,8 @@ class MainFrame final : public wxFrame
 	wxWindow* linkFileStatus = nullptr;
 	wxWindow* sourceTokenStatus = nullptr;
 	wxWindow* targetTokenStatus = nullptr;
+
+	wxCheckBox* ditchCheck = nullptr;
 
 	wxButton* startButton = nullptr;
 

--- a/ProvinceMapper/Source/Frames/PixelReader/PixelReader.cpp
+++ b/ProvinceMapper/Source/Frames/PixelReader/PixelReader.cpp
@@ -13,7 +13,7 @@ void* PixelReader::Entry()
 			// border or regular pixel?
 			if (!isSameColorAtCoords(x, y, x - 1, y))
 			{
-				if (x > 0)
+				if (ditchAdjacencies && x > 0)
 				{
 					const auto borderOffs = coordsToOffset(x - 1, y, image->GetSize().GetX());
 					definitions->registerNeighbor(pixelPack(rgb[offs], rgb[offs + 1], rgb[offs + 2]),
@@ -23,7 +23,7 @@ void* PixelReader::Entry()
 			}
 			if (!isSameColorAtCoords(x, y, x + 1, y))
 			{
-				if (x < image->GetSize().GetX() - 1)
+				if (ditchAdjacencies && x < image->GetSize().GetX() - 1)
 				{
 					const auto borderOffs = coordsToOffset(x + 1, y, image->GetSize().GetX());
 					definitions->registerNeighbor(pixelPack(rgb[offs], rgb[offs + 1], rgb[offs + 2]),
@@ -33,7 +33,7 @@ void* PixelReader::Entry()
 			}
 			if (!isSameColorAtCoords(x, y, x, y - 1))
 			{
-				if (y > 0)
+				if (ditchAdjacencies && y > 0)
 				{
 					const auto borderOffs = coordsToOffset(x, y - 1, image->GetSize().GetX());
 					definitions->registerNeighbor(pixelPack(rgb[offs], rgb[offs + 1], rgb[offs + 2]),
@@ -43,7 +43,7 @@ void* PixelReader::Entry()
 			}
 			if (!isSameColorAtCoords(x, y, x, y + 1))
 			{
-				if (y < image->GetSize().GetY() - 1)
+				if (ditchAdjacencies && y < image->GetSize().GetY() - 1)
 				{
 					const auto borderOffs = coordsToOffset(x, y + 1, image->GetSize().GetX());
 					definitions->registerNeighbor(pixelPack(rgb[offs], rgb[offs + 1], rgb[offs + 2]),

--- a/ProvinceMapper/Source/Frames/PixelReader/PixelReader.h
+++ b/ProvinceMapper/Source/Frames/PixelReader/PixelReader.h
@@ -11,16 +11,18 @@ class PixelReader final: public wxThread
 {
   public:
 	PixelReader(wxEvtHandler* parent): wxThread(wxTHREAD_JOINABLE), eventHandler(parent) {}
-	void prepare(wxImage* theImage, const std::shared_ptr<DefinitionsInterface>& theDefinitions)
+	void prepare(wxImage* theImage, const std::shared_ptr<DefinitionsInterface>& theDefinitions, const bool theDitch)
 	{
 		image = theImage;
 		definitions = theDefinitions;
+		ditchAdjacencies = theDitch;
 	}
 
   private:
 	void* Entry() override;
 	wxImage* image = nullptr;
 	std::shared_ptr<DefinitionsInterface> definitions;
+	bool ditchAdjacencies = false;
 
 	[[nodiscard]] bool isSameColorAtCoords(int ax, int ay, int bx, int by) const;
 

--- a/ProvinceMapper/Source/LinkMapper/LinkMapper.cpp
+++ b/ProvinceMapper/Source/LinkMapper/LinkMapper.cpp
@@ -17,7 +17,8 @@ void LinkMapper::loadMappings(const std::filesystem::path& linksFile,
 	targetToken = std::move(theTargetToken);
 
 	registerKeys();
-	parseFile(linksFile);
+	if (!linksFile.empty())
+		parseFile(linksFile);
 	clearRegisteredKeywords();
 	if (versions.empty())
 	{

--- a/ProvinceMapper/Source/Localization/LocalizationMapper.cpp
+++ b/ProvinceMapper/Source/Localization/LocalizationMapper.cpp
@@ -17,14 +17,31 @@ void LocalizationMapper::scrapeSourceDir(const std::filesystem::path& dirPath)
 	}
 
 	if (commonItems::DoesFolderExist(dirPath / "../localisation")) // ck2, eu4, vic2
+	{
 		actualPath = dirPath / "../localisation";
+		Log(LogLevel::Info) << "Priming for Ck2/EU4/Vic2 Source Locs.";
+	}
 	else if (commonItems::DoesFolderExist(dirPath / "../localization/english")) // ck3, imp, vic3
+	{
 		actualPath = dirPath / "../localization/english";
+		Log(LogLevel::Info) << "Priming for CK3/Imp/Vic3 Source Locs.";
+	}
+	else if (commonItems::DoesFolderExist(dirPath / "../../main_menu/localization/english")) // eu5
+	{
+		actualPath = dirPath / "../../main_menu/localization/english";
+		Log(LogLevel::Info) << "Priming for EU5 Source Locs.";
+	}
 	else if (actualPath.empty())
+	{
+		Log(LogLevel::Warning) << "No source locs found!";
 		return;
+	}
 
 	for (const auto& fileName: commonItems::GetAllFilesInFolderRecursive(actualPath))
+	{
+		Log(LogLevel::Debug) << "into file :::::::::: " << (actualPath / fileName).string();
 		scrapeFile(actualPath / fileName, LocType::SOURCE);
+	}
 }
 
 void LocalizationMapper::scrapeTargetDir(const std::filesystem::path& dirPath)
@@ -39,11 +56,25 @@ void LocalizationMapper::scrapeTargetDir(const std::filesystem::path& dirPath)
 	}
 
 	if (commonItems::DoesFolderExist(dirPath / "../localisation")) // ck2, eu4, vic2
+	{
 		actualPath = dirPath / "../localisation";
+		Log(LogLevel::Info) << "Priming for Ck2/EU4/Vic2 Target Locs.";
+	}
 	else if (commonItems::DoesFolderExist(dirPath / "../localization/english")) // ck3, imp, vic3
+	{
 		actualPath = dirPath / "../localization/english";
+		Log(LogLevel::Info) << "Priming for CK3/Imp/Vic3 Target Locs.";
+	}
+	else if (commonItems::DoesFolderExist(dirPath / "../../main_menu/localization/english")) // eu5
+	{
+		actualPath = dirPath / "../../main_menu/localization/english";
+		Log(LogLevel::Warning) << "No target locs found!";
+	}
 	else if (actualPath.empty())
+	{
+
 		return;
+	}
 
 	for (const auto& fileName: commonItems::GetAllFilesInFolderRecursive(actualPath))
 		scrapeFile(actualPath / fileName, LocType::TARGET);

--- a/ProvinceMapper/Source/Localization/LocalizationMapper.cpp
+++ b/ProvinceMapper/Source/Localization/LocalizationMapper.cpp
@@ -38,10 +38,7 @@ void LocalizationMapper::scrapeSourceDir(const std::filesystem::path& dirPath)
 	}
 
 	for (const auto& fileName: commonItems::GetAllFilesInFolderRecursive(actualPath))
-	{
-		Log(LogLevel::Debug) << "into file :::::::::: " << (actualPath / fileName).string();
 		scrapeFile(actualPath / fileName, LocType::SOURCE);
-	}
 }
 
 void LocalizationMapper::scrapeTargetDir(const std::filesystem::path& dirPath)

--- a/ProvinceMapper/Source/Localization/YmlScraper.cpp
+++ b/ProvinceMapper/Source/Localization/YmlScraper.cpp
@@ -10,7 +10,7 @@ YmlScraper::YmlScraper(const std::filesystem::path& fileName)
 	fileStream.close();
 }
 
-void YmlScraper::scrapeStream(std::istream& theStream)
+void YmlScraper::scrapeStream(std::istream& theStream, bool degrade = false)
 {
 	std::string line;
 	getline(theStream, line); // This is header line.
@@ -34,8 +34,13 @@ void YmlScraper::scrapeStream(std::istream& theStream)
 			continue;
 		auto value = newLine.substr(quoteLoc + 1, quote2Loc - quoteLoc - 1);
 
-		// we're degrading to 1252 because we usually have mix of mapdatanames, and old 1252 locs, all of which are shady.
-		value = commonItems::convertUTF8ToWin1252(value);
+		if (degrade)
+		{
+			// we're degrading to 1252 because we usually have mix of mapdatanames, and old 1252 locs, all of which are shady.
+			value = commonItems::convertUTF8ToWin1252(value);
+		}
+
 		localizations[key] = value;
+		Log(LogLevel::Debug) << " -- " << key << "  :   " << value;
 	}
 }

--- a/ProvinceMapper/Source/Localization/YmlScraper.h
+++ b/ProvinceMapper/Source/Localization/YmlScraper.h
@@ -12,7 +12,7 @@ class YmlScraper
 	[[nodiscard]] const auto& getLocalizations() const { return localizations; }
 
   private:
-	void scrapeStream(std::istream& theStream, bool degrade = false);
+	void scrapeStream(std::istream& theStream);
 
 	std::map<std::string, std::string> localizations;
 };

--- a/ProvinceMapper/Source/Localization/YmlScraper.h
+++ b/ProvinceMapper/Source/Localization/YmlScraper.h
@@ -12,7 +12,7 @@ class YmlScraper
 	[[nodiscard]] const auto& getLocalizations() const { return localizations; }
 
   private:
-	void scrapeStream(std::istream& theStream);
+	void scrapeStream(std::istream& theStream, bool degrade = false);
 
 	std::map<std::string, std::string> localizations;
 };

--- a/ProvinceMapper/Source/Provinces/Province.cpp
+++ b/ProvinceMapper/Source/Provinces/Province.cpp
@@ -1,13 +1,17 @@
 #include "Province.h"
+#include <Configuration/Configuration.h>
 #include <algorithm>
 #include <numeric>
-#include <Configuration/Configuration.h>
 
 Province::Province(std::string theID, const unsigned char tr, const unsigned char tg, const unsigned char tb, std::string theName):
 	 ID(std::move(theID)), r(tr), g(tg), b(tb), mapDataName(std::move(theName))
 {
 }
 
+void Province::setProvinceName(std::string name)
+{
+	provinceName = std::move(name);
+}
 
 void Province::setAreaName(std::string name)
 {
@@ -22,6 +26,11 @@ void Province::setRegionName(std::string name)
 void Province::setSuperRegionName(std::string name)
 {
 	superRegionName = std::move(name);
+}
+
+void Province::setContinentName(std::string name)
+{
+	continentName = std::move(name);
 }
 
 void Province::addProvinceType(std::string name)
@@ -72,25 +81,25 @@ std::string Province::miscName() const
 	name = "\nTypes: ";
 	if (!provinceTypes.empty())
 	{
-		name += std::accumulate(
-			 ++provinceTypes.begin(),
-			 provinceTypes.end(),
-			 *provinceTypes.begin(), 
-			 [](const std::string& a, const std::string& b) {
-				 return a + ", " + b;
-			 });
+		name += std::accumulate(++provinceTypes.begin(), provinceTypes.end(), *provinceTypes.begin(), [](const std::string& a, const std::string& b) {
+			return a + ", " + b;
+		});
 	}
 	else
 	{
 		name += "normal";
 	}
 
+	if (provinceName)
+		name += "\nProvince: " + *provinceName;
 	if (areaName)
 		name += "\nArea: " + *areaName;
 	if (regionName)
 		name += "\nRegion: " + *regionName;
 	if (superRegionName)
 		name += "\nSuperRegion: " + *superRegionName;
+	if (continentName)
+		name += "\nContinent: " + *continentName;
 	return name;
 }
 
@@ -111,7 +120,8 @@ bool Province::isWater() const
 	}
 
 	// For games like I:R and CK3, province type is defined and can be used.
-	return provinceTypes.contains("sea_zones") || provinceTypes.contains("river_provinces") || provinceTypes.contains("lakes") || provinceTypes.contains("impassable_seas");
+	return provinceTypes.contains("sea_zones") || provinceTypes.contains("river_provinces") || provinceTypes.contains("lakes") ||
+			 provinceTypes.contains("impassable_seas");
 }
 
 bool Province::isImpassable() const

--- a/ProvinceMapper/Source/Provinces/Province.h
+++ b/ProvinceMapper/Source/Provinces/Province.h
@@ -13,16 +13,20 @@ class Province final
 
 	[[nodiscard]] std::string bespokeName() const;
 	[[nodiscard]] std::string miscName() const;
+	[[nodiscard]] const std::optional<std::string>& getProvinceName() const { return provinceName; }
 	[[nodiscard]] const std::optional<std::string>& getAreaName() const { return areaName; }
 	[[nodiscard]] const std::optional<std::string>& getRegionName() const { return regionName; }
 	[[nodiscard]] const std::optional<std::string>& getSuperRegionName() const { return superRegionName; }
+	[[nodiscard]] const std::optional<std::string>& getContinentName() const { return continentName; }
 	[[nodiscard]] const std::set<std::string>& getProvinceTypes() const { return provinceTypes; }
 	[[nodiscard]] bool isWater() const;
 	[[nodiscard]] bool isImpassable() const;
 
+	void setProvinceName(std::string name);
 	void setAreaName(std::string name);
 	void setRegionName(std::string name);
 	void setSuperRegionName(std::string name);
+	void setContinentName(std::string name);
 	void addProvinceType(std::string name);
 
 	bool operator==(const Province& rhs) const;
@@ -40,9 +44,11 @@ class Province final
 	std::vector<Pixel> borderPixels;
 
   private:
+	std::optional<std::string> provinceName; // in case this "province" is actually a /location/
 	std::optional<std::string> areaName;
 	std::optional<std::string> regionName;
 	std::optional<std::string> superRegionName;
+	std::optional<std::string> continentName; 
 	std::set<std::string> provinceTypes;
 };
 


### PR DESCRIPTION
A new checkmark for Ditch Adjacencies so they aren't generated and ditched automatically on Begin! button:

![image](https://github.com/user-attachments/assets/5eafc9dc-d6ce-4f4b-8c79-c8e501438ac0)

Uncheck it unless you actually need these (only useful for Vic3 and Hoi4 converters and only after map changes.
Adjacencies are (IIRC) used to calculate pathing in HoI4, and in Vic3 they are used to calculate what are and aren't coastlines.
They are costly to generate and especially dump over mobile VPN to a network drive at snail's pace on every startup.