### PR TITLE
Heightmap view

### DIFF
--- a/ProvinceMapper/Source/Frames/Images/ImageCanvas.h
+++ b/ProvinceMapper/Source/Frames/Images/ImageCanvas.h
@@ -62,6 +62,7 @@ class ImageCanvas final: public wxScrolledCanvas
 	void clearScale() { oldScaleFactor = scaleFactor; }
 	void clearOldScrollH() { oldScrollPositionH = GetScrollPos(wxHORIZONTAL); }
 	void clearOldScrollV() { oldScrollPositionV = GetScrollPos(wxVERTICAL); }
+	void setImage(wxImage* newImage);
 
 	void activateLinkByIndex(int row);
 	void activateLinkByID(int ID);
@@ -104,6 +105,7 @@ class ImageCanvas final: public wxScrolledCanvas
 	void stageMoveVersionRight() const;
 	void stageDelaunayTriangulate() const;
 	void stageActivateTriangulationPairByID(int ID) const;
+	void refreshStrafedPixelColors();
 
 	[[nodiscard]] const std::vector<std::shared_ptr<Province>>& getRelevantProvinces(const std::shared_ptr<LinkMapping>& link) const;
 

--- a/ProvinceMapper/Source/Frames/Images/ImageFrame.h
+++ b/ProvinceMapper/Source/Frames/Images/ImageFrame.h
@@ -15,7 +15,7 @@ class Configuration;
 class wxAutoBufferedPaintDC;
 enum
 {
-	ID_TOGGLE_SOURCE_HEIGHTMAP = wxID_HIGHEST + 1
+	ID_TOGGLE_HEIGHTMAP = wxID_HIGHEST + 1
 };
 
 class ImageFrame final: public wxFrame
@@ -28,6 +28,7 @@ class ImageFrame final: public wxFrame
 		 wxImage* sourceImg,
 		 wxImage* sourceHeightmapImg,
 		 wxImage* targetImg,
+		 wxImage* targetHeightmapImg,
 		 const std::shared_ptr<DefinitionsInterface>& sourceDefs,
 		 const std::shared_ptr<DefinitionsInterface>& targetDefs,
 		 std::shared_ptr<Configuration> theConfiguration);
@@ -54,7 +55,7 @@ class ImageFrame final: public wxFrame
 	void onToggleOrientation(wxCommandEvent& event);
 	void onToggleBlack(wxCommandEvent& event);
 	void onToggleTriangulationMesh(wxCommandEvent& event);
-	void onToggleSourceHeightmap(wxCommandEvent& event);
+	void onToggleHeightmap(wxCommandEvent& event);
 	void onClose(const wxCloseEvent& event);
 	void onRefresh(const wxCommandEvent& event);
 	void onTriangulate(wxCommandEvent& event);
@@ -98,7 +99,9 @@ class ImageFrame final: public wxFrame
 	std::shared_ptr<Configuration> configuration;
 	wxImage* sourcePrimaryImage = nullptr;
 	wxImage* sourceHeightmapImage = nullptr;
-	bool showingSourceHeightmap = false;
+	wxImage* targetPrimaryImage = nullptr;
+	wxImage* targetHeightmapImage = nullptr;
+	bool showingHeightmap = false;
 
   protected:
 	wxEvtHandler* eventHandler;

--- a/ProvinceMapper/Source/Frames/Images/ImageFrame.h
+++ b/ProvinceMapper/Source/Frames/Images/ImageFrame.h
@@ -13,6 +13,11 @@ class ImageCanvas;
 enum class ImageTabSelector;
 class Configuration;
 class wxAutoBufferedPaintDC;
+enum
+{
+	ID_TOGGLE_SOURCE_HEIGHTMAP = wxID_HIGHEST + 1
+};
+
 class ImageFrame final: public wxFrame
 {
   public:
@@ -21,6 +26,7 @@ class ImageFrame final: public wxFrame
 		 const wxSize& size,
 		 const std::shared_ptr<LinkMappingVersion>& theActiveVersion,
 		 wxImage* sourceImg,
+		 wxImage* sourceHeightmapImg,
 		 wxImage* targetImg,
 		 const std::shared_ptr<DefinitionsInterface>& sourceDefs,
 		 const std::shared_ptr<DefinitionsInterface>& targetDefs,
@@ -48,6 +54,7 @@ class ImageFrame final: public wxFrame
 	void onToggleOrientation(wxCommandEvent& event);
 	void onToggleBlack(wxCommandEvent& event);
 	void onToggleTriangulationMesh(wxCommandEvent& event);
+	void onToggleSourceHeightmap(wxCommandEvent& event);
 	void onClose(const wxCloseEvent& event);
 	void onRefresh(const wxCommandEvent& event);
 	void onTriangulate(wxCommandEvent& event);
@@ -89,6 +96,9 @@ class ImageFrame final: public wxFrame
 	bool lock = false;
 
 	std::shared_ptr<Configuration> configuration;
+	wxImage* sourcePrimaryImage = nullptr;
+	wxImage* sourceHeightmapImage = nullptr;
+	bool showingSourceHeightmap = false;
 
   protected:
 	wxEvtHandler* eventHandler;

--- a/ProvinceMapper/Source/Frames/MainFrame.cpp
+++ b/ProvinceMapper/Source/Frames/MainFrame.cpp
@@ -464,6 +464,7 @@ void MainFrame::initImageFrame()
 		 sourceImg,
 		 sourceHeightmapImg,
 		 targetImg,
+		 targetHeightmapImg,
 		 sourceDefs,
 		 targetDefs,
 		 configuration);
@@ -471,7 +472,7 @@ void MainFrame::initImageFrame()
 	auto* menuDropDown = new wxMenu;
 	menuDropDown->Append(wxID_REVERT, "Toggle Orientation");
 	menuDropDown->Append(wxID_BOLD, "Toggle The Shade");
-	menuDropDown->Append(ID_TOGGLE_SOURCE_HEIGHTMAP, "Toggle Source Heightmap");
+	menuDropDown->Append(ID_TOGGLE_HEIGHTMAP, "Toggle Heightmap");
 	menuDropDown->Append(wxID_VIEW_SMALLICONS, "Toggle the Triangulation Mesh");
 	auto* toolbarDropDown = new wxMenu;
 	toolbarDropDown->Append(wxMENU_SHOW_TOOLBAR, "Show Toolbar");

--- a/ProvinceMapper/Source/Frames/MainFrame.cpp
+++ b/ProvinceMapper/Source/Frames/MainFrame.cpp
@@ -394,6 +394,22 @@ void MainFrame::initImageFrame()
 		sourceRiversImg->LoadFile(configuration->getSourceDir()->string() + "/rivers.bmp");
    	if (commonItems::DoesFileExist(*configuration->getSourceDir() / "heightmap.png"))
 		sourceHeightmapImg->LoadFile(configuration->getSourceDir()->string() + "/heightmap.png");
+	if (sourceHeightmapImg->IsOk() && sourceImg->IsOk())
+	{
+		const auto heightmapSize = sourceHeightmapImg->GetSize();
+		const auto mapSize = sourceImg->GetSize();
+		if (heightmapSize != mapSize)
+		{
+			const auto widthMultiple = heightmapSize.GetWidth() % mapSize.GetWidth() == 0;
+			const auto heightMultiple = heightmapSize.GetHeight() % mapSize.GetHeight() == 0;
+			if (widthMultiple && heightMultiple)
+			{
+				Log(LogLevel::Info) << "Scaling source heightmap from " << heightmapSize.GetWidth() << "x" << heightmapSize.GetHeight() << " down to "
+					 << mapSize.GetWidth() << "x" << mapSize.GetHeight() << '.';
+				sourceHeightmapImg->Rescale(mapSize.GetWidth(), mapSize.GetHeight(), wxIMAGE_QUALITY_HIGH);
+			}
+		}
+	}
 
 	targetImg = new wxImage();
 	targetRiversImg = new wxImage();
@@ -410,6 +426,22 @@ void MainFrame::initImageFrame()
 		targetRiversImg->LoadFile(configuration->getTargetDir()->string() + "/rivers.bmp");
 	if (commonItems::DoesFileExist(*configuration->getTargetDir() / "heightmap.png"))
 		targetHeightmapImg->LoadFile(configuration->getTargetDir()->string() + "/heightmap.png");
+	if (targetHeightmapImg->IsOk() && targetImg->IsOk())
+	{
+		const auto heightmapSize = targetHeightmapImg->GetSize();
+		const auto mapSize = targetImg->GetSize();
+		if (heightmapSize != mapSize)
+		{
+			const auto widthMultiple = heightmapSize.GetWidth() % mapSize.GetWidth() == 0;
+			const auto heightMultiple = heightmapSize.GetHeight() % mapSize.GetHeight() == 0;
+			if (widthMultiple && heightMultiple)
+			{
+				Log(LogLevel::Info) << "Scaling target heightmap from " << heightmapSize.GetWidth() << "x" << heightmapSize.GetHeight() << " down to "
+					 << mapSize.GetWidth() << "x" << mapSize.GetHeight() << '.';
+				targetHeightmapImg->Rescale(mapSize.GetWidth(), mapSize.GetHeight(), wxIMAGE_QUALITY_HIGH);
+			}
+		}
+	}
 
 	mergeRivers();
 

--- a/ProvinceMapper/Source/Frames/MainFrame.cpp
+++ b/ProvinceMapper/Source/Frames/MainFrame.cpp
@@ -392,7 +392,7 @@ void MainFrame::initImageFrame()
 		sourceRiversImg->LoadFile(configuration->getSourceDir()->string() + "/rivers.png");
 	else if (commonItems::DoesFileExist(*configuration->getSourceDir() / "rivers.bmp"))
 		sourceRiversImg->LoadFile(configuration->getSourceDir()->string() + "/rivers.bmp");
-   if (commonItems::DoesFileExist(*configuration->getSourceDir() / "heightmap.png"))
+   	if (commonItems::DoesFileExist(*configuration->getSourceDir() / "heightmap.png"))
 		sourceHeightmapImg->LoadFile(configuration->getSourceDir()->string() + "/heightmap.png");
 
 	targetImg = new wxImage();
@@ -457,11 +457,21 @@ void MainFrame::initImageFrame()
 	if (configuration->getImageFrameSize())
 		size = wxSize(configuration->getImageFrameSize()->x, configuration->getImageFrameSize()->y);
 	const auto maximize = configuration->isImageFrameMaximized();
-	imageFrame = new ImageFrame(this, position, size, linkMapper.getActiveVersion(), sourceImg, targetImg, sourceDefs, targetDefs, configuration);
+	imageFrame = new ImageFrame(this,
+		 position,
+		 size,
+		 linkMapper.getActiveVersion(),
+		 sourceImg,
+		 sourceHeightmapImg,
+		 targetImg,
+		 sourceDefs,
+		 targetDefs,
+		 configuration);
 
 	auto* menuDropDown = new wxMenu;
 	menuDropDown->Append(wxID_REVERT, "Toggle Orientation");
 	menuDropDown->Append(wxID_BOLD, "Toggle The Shade");
+	menuDropDown->Append(ID_TOGGLE_SOURCE_HEIGHTMAP, "Toggle Source Heightmap");
 	menuDropDown->Append(wxID_VIEW_SMALLICONS, "Toggle the Triangulation Mesh");
 	auto* toolbarDropDown = new wxMenu;
 	toolbarDropDown->Append(wxMENU_SHOW_TOOLBAR, "Show Toolbar");

--- a/ProvinceMapper/Source/Frames/MainFrame.cpp
+++ b/ProvinceMapper/Source/Frames/MainFrame.cpp
@@ -381,6 +381,7 @@ void MainFrame::initImageFrame()
 	wxLogNull AD; // disable warning about proprietary and thus unsupported sRGB profiles in PDX PNGs.
 	sourceImg = new wxImage();
 	sourceRiversImg = new wxImage();
+	sourceHeightmapImg = new wxImage();
 	if (commonItems::DoesFileExist(*configuration->getSourceDir() / "provinces.png"))
 		sourceImg->LoadFile(configuration->getSourceDir()->string() + "/provinces.png");
 	else if (commonItems::DoesFileExist(*configuration->getSourceDir() / "provinces.bmp"))
@@ -391,9 +392,12 @@ void MainFrame::initImageFrame()
 		sourceRiversImg->LoadFile(configuration->getSourceDir()->string() + "/rivers.png");
 	else if (commonItems::DoesFileExist(*configuration->getSourceDir() / "rivers.bmp"))
 		sourceRiversImg->LoadFile(configuration->getSourceDir()->string() + "/rivers.bmp");
+   if (commonItems::DoesFileExist(*configuration->getSourceDir() / "heightmap.png"))
+		sourceHeightmapImg->LoadFile(configuration->getSourceDir()->string() + "/heightmap.png");
 
 	targetImg = new wxImage();
 	targetRiversImg = new wxImage();
+	targetHeightmapImg = new wxImage();
 	if (commonItems::DoesFileExist(*configuration->getTargetDir() / "provinces.png"))
 		targetImg->LoadFile(configuration->getTargetDir()->string() + "/provinces.png");
 	else if (commonItems::DoesFileExist(*configuration->getTargetDir() / "provinces.bmp"))
@@ -404,6 +408,8 @@ void MainFrame::initImageFrame()
 		targetRiversImg->LoadFile(configuration->getTargetDir()->string() + "/rivers.png");
 	else if (commonItems::DoesFileExist(*configuration->getTargetDir() / "rivers.bmp"))
 		targetRiversImg->LoadFile(configuration->getTargetDir()->string() + "/rivers.bmp");
+	if (commonItems::DoesFileExist(*configuration->getTargetDir() / "heightmap.png"))
+		targetHeightmapImg->LoadFile(configuration->getTargetDir()->string() + "/heightmap.png");
 
 	mergeRivers();
 

--- a/ProvinceMapper/Source/Frames/MainFrame.h
+++ b/ProvinceMapper/Source/Frames/MainFrame.h
@@ -97,6 +97,8 @@ class MainFrame final: public wxFrame
 	wxImage* targetImg = nullptr;
 	wxImage* sourceRiversImg = nullptr;
 	wxImage* targetRiversImg = nullptr;
+	wxImage* sourceHeightmapImg = nullptr;
+	wxImage* targetHeightmapImg = nullptr;
 
 	wxDirPickerCtrl* sourceDirPicker = nullptr;
 	wxDirPickerCtrl* targetDirPicker = nullptr;


### PR DESCRIPTION
The provinceMapper now attempts to load heightmap.png from source and target dirs.
<img width="256" height="134" alt="menu item" src="https://github.com/user-attachments/assets/73d42325-f0c8-4355-a01a-5186affd9cc4" />
<img width="1909" height="504" alt="heightmap view" src="https://github.com/user-attachments/assets/43dc036e-d69f-44a8-848f-b99e33e4e346" />
The triangulation mesh can still be shown:
<img width="1917" height="1027" alt="heightmap view with triangulation mesh" src="https://github.com/user-attachments/assets/bbbd42ad-fe1f-4ab0-887c-31ff0a04d3f5" />
