### PR TITLE
Fix CK3 impassables still being automapped

### DIFF
--- a/ProvinceMapper/Source/LinkMapper/Automapper.cpp
+++ b/ProvinceMapper/Source/LinkMapper/Automapper.cpp
@@ -594,9 +594,9 @@ void Automapper::generateLinks(wxTaskBarButton* taskBarBtn, bool mapSourceImpass
 		//    Try to use the most matching available source province (including impassables) to map them.
 		Log(LogLevel::Debug) << "Link generation step 7...";
 		forUnmappedTargetsEvaluateAllMatches();
-		if (taskBarBtn)
-			taskBarBtn->SetProgressValue(++currentProgress);
 	}
+	if (taskBarBtn)
+		taskBarBtn->SetProgressValue(++currentProgress);
 
 	if (mapTargetImpassables)
 	{
@@ -604,9 +604,9 @@ void Automapper::generateLinks(wxTaskBarButton* taskBarBtn, bool mapSourceImpass
 		//    Try to use the most matching available target province (including impassables) to map them.
 		Log(LogLevel::Debug) << "Link generation step 8...";
 		forUnmappedSourcesEvaluateAllMatches();
-		if (taskBarBtn)
-			taskBarBtn->SetProgressValue(++currentProgress);
 	}
+	if (taskBarBtn)
+		taskBarBtn->SetProgressValue(++currentProgress);
 
 	// 9. For all yet unmapped non-impassable target provinces, we're running out of options, so we turn to theft.
 	//    Check if we can steal a source province from an existing many-to-one link.
@@ -640,12 +640,16 @@ void Automapper::generateLinks(wxTaskBarButton* taskBarBtn, bool mapSourceImpass
 	forUnmappedSourcesEvaluateAllNonImpassableMatches();
 	if (taskBarBtn)
 		taskBarBtn->SetProgressValue(++currentProgress);
-	Log(LogLevel::Debug) << "Link generation step 15...";
-	forUnmappedTargetsEvaluateAllMatches();
+	if (mapSourceImpassables) {
+		Log(LogLevel::Debug) << "Link generation step 15...";
+		forUnmappedTargetsEvaluateAllMatches();
+	}
 	if (taskBarBtn)
 		taskBarBtn->SetProgressValue(++currentProgress);
-	Log(LogLevel::Debug) << "Link generation step 16...";
-	forUnmappedSourcesEvaluateAllMatches();
+	if (mapTargetImpassables) {
+		Log(LogLevel::Debug) << "Link generation step 16...";
+		forUnmappedSourcesEvaluateAllMatches();
+	}
 	if (taskBarBtn)
 		taskBarBtn->SetProgressValue(++currentProgress);
 

--- a/ProvinceMapper/Source/Provinces/Province.h
+++ b/ProvinceMapper/Source/Provinces/Province.h
@@ -1,14 +1,28 @@
 #ifndef PROVINCE_H
 #define PROVINCE_H
 #include "Pixel.h"
+#include <bitset>
 #include <optional>
 #include <string>
 #include <vector>
-#include <set>
 
 class Province final
 {
   public:
+	enum class ProvinceType: unsigned char
+	{
+		SeaZones,
+		Wasteland,
+		ImpassableTerrain,
+		Uninhabitable,
+		RiverProvinces,
+		Lakes,
+		ImpassableMountains,
+		ImpassableSeas,
+		NonOwnable,
+		Count
+	};
+
 	Province(std::string theID, unsigned char tr, unsigned char tg, unsigned char tb, std::string theName);
 
 	[[nodiscard]] std::string bespokeName() const;
@@ -18,7 +32,8 @@ class Province final
 	[[nodiscard]] const std::optional<std::string>& getRegionName() const { return regionName; }
 	[[nodiscard]] const std::optional<std::string>& getSuperRegionName() const { return superRegionName; }
 	[[nodiscard]] const std::optional<std::string>& getContinentName() const { return continentName; }
-	[[nodiscard]] const std::set<std::string>& getProvinceTypes() const { return provinceTypes; }
+	[[nodiscard]] const std::bitset<static_cast<size_t>(ProvinceType::Count)>& getProvinceTypes() const { return provinceTypes; }
+	[[nodiscard]] bool hasProvinceType(ProvinceType type) const { return provinceTypes.test(static_cast<size_t>(type)); }
 	[[nodiscard]] bool isWater() const;
 	[[nodiscard]] bool isImpassable() const;
 
@@ -27,7 +42,7 @@ class Province final
 	void setRegionName(std::string name);
 	void setSuperRegionName(std::string name);
 	void setContinentName(std::string name);
-	void addProvinceType(std::string name);
+	void addProvinceType(const std::string& name);
 
 	bool operator==(const Province& rhs) const;
 	bool operator==(const Pixel& rhs) const;
@@ -49,7 +64,7 @@ class Province final
 	std::optional<std::string> regionName;
 	std::optional<std::string> superRegionName;
 	std::optional<std::string> continentName; 
-	std::set<std::string> provinceTypes;
+	std::bitset<static_cast<size_t>(ProvinceType::Count)> provinceTypes;
 };
 
 #endif // PROVINCE_H


### PR DESCRIPTION
Forgot that steps 15 and 16 are a repetition of steps 7 and 8.
Also refactored province types to use bitsets for better performance and memory usage (with the amount of provinces EU5 has, this becomes more important).

Tested on the links file from Vielus, the Norwegian impassable is now actually not mapped:
<img width="1294" height="666" alt="obraz" src="https://github.com/user-attachments/assets/4c3ed394-1fc8-4800-8b21-2745ccb8f5c2" />
