### PR TITLE
Exclude `non_ownable` provinces from CK3ToEU5 automapping

### DIFF
--- a/ProvinceMapper/Source/Frames/Unmapped/UnmappedFrame.cpp
+++ b/ProvinceMapper/Source/Frames/Unmapped/UnmappedFrame.cpp
@@ -47,24 +47,24 @@ UnmappedFrame::UnmappedFrame(wxWindow* parent,
 	});
 	sizer->Add(excludeWaterProvincesCheckbox);
 
-	excludeImpassablesCheckbox = new wxCheckBox(this, wxID_ANY, "Exclude impassables");
-	excludeImpassablesCheckbox->Bind(wxEVT_CHECKBOX, [this](wxCommandEvent& event) {
-		if (excludeImpassablesCheckbox->GetValue())
+	excludeImpassablesAndWastelandsCheckbox = new wxCheckBox(this, wxID_ANY, "Exclude impassables and wastelands");
+	excludeImpassablesAndWastelandsCheckbox->Bind(wxEVT_CHECKBOX, [this](wxCommandEvent& event) {
+		if (excludeImpassablesAndWastelandsCheckbox->GetValue())
 		{
-			sources->setExcludeImpassables(true);
-			targets->setExcludeImpassables(true);
+			sources->setExcludeImpassablesAndWastelands(true);
+			targets->setExcludeImpassablesAndWastelands(true);
 		}
 		else
 		{
-			sources->setExcludeImpassables(false);
-			targets->setExcludeImpassables(false);
+			sources->setExcludeImpassablesAndWastelands(false);
+			targets->setExcludeImpassablesAndWastelands(false);
 		}
 	});
-	sizer->Add(excludeImpassablesCheckbox);
+	sizer->Add(excludeImpassablesAndWastelandsCheckbox);
 	if (configuration->getSourceToken() == "eu4" || configuration->getTargetToken() == "eu4")
 	{
 		// Adding EU4 would require serious changes.
-		excludeImpassablesCheckbox->Hide();
+		excludeImpassablesAndWastelandsCheckbox->Hide();
 	}
 
 	sizer->Add(notebook, wxSizerFlags(1).Expand().Border(wxALL, 1));

--- a/ProvinceMapper/Source/Frames/Unmapped/UnmappedFrame.h
+++ b/ProvinceMapper/Source/Frames/Unmapped/UnmappedFrame.h
@@ -38,7 +38,7 @@ class UnmappedFrame final: public wxFrame
 	UnmappedTab* sources;
 	UnmappedTab* targets;
 	wxCheckBox* excludeWaterProvincesCheckbox;
-	wxCheckBox* excludeImpassablesCheckbox;
+	wxCheckBox* excludeImpassablesAndWastelandsCheckbox;
 
 	std::shared_ptr<Configuration> configuration;
 

--- a/ProvinceMapper/Source/Frames/Unmapped/UnmappedTab.cpp
+++ b/ProvinceMapper/Source/Frames/Unmapped/UnmappedTab.cpp
@@ -56,7 +56,8 @@ const std::vector<std::shared_ptr<Province>> UnmappedTab::getRelevantProvinces()
 	if (excludeImpassablesAndWastelands)
 	{
 		std::vector<std::shared_ptr<Province>> filteredProvinces;
-		for (auto &p : relevantProvs | std::views::filter([](const std::shared_ptr<Province>& p){ return !p->isImpassableOrWasteland(); })) {
+		for (auto& p: relevantProvs | std::views::filter([](const std::shared_ptr<Province>& p) { return !p->isImpassableOrWasteland(); }))
+		{
 			filteredProvinces.push_back(p);
 		}
 		relevantProvs = filteredProvinces;

--- a/ProvinceMapper/Source/Frames/Unmapped/UnmappedTab.cpp
+++ b/ProvinceMapper/Source/Frames/Unmapped/UnmappedTab.cpp
@@ -38,32 +38,31 @@ UnmappedTab::UnmappedTab(wxWindow* parent, std::shared_ptr<LinkMappingVersion> t
 
 const std::vector<std::shared_ptr<Province>> UnmappedTab::getRelevantProvinces() const
 {
-	std::vector<std::shared_ptr<Province>> relevantProvinces;
+	std::vector<std::shared_ptr<Province>> relevantProvs;
 	if (selector == ImageTabSelector::SOURCE)
-		relevantProvinces = *version->getUnmappedSources();
+		relevantProvs = *version->getUnmappedSources();
 	else
-		relevantProvinces = *version->getUnmappedTargets();
+		relevantProvs = *version->getUnmappedTargets();
 
 	if (excludeWaterProvinces)
 	{
 		std::vector<std::shared_ptr<Province>> filteredProvinces;
-		for (auto &p : relevantProvinces | std::views::filter([](std::shared_ptr<Province> p){ return !p->isWater(); })) {
+		for (auto& p: relevantProvs | std::views::filter([](const std::shared_ptr<Province>& p) { return !p->isWater(); }))
+		{
 			filteredProvinces.push_back(p);
 		}
-		relevantProvinces = filteredProvinces;
+		relevantProvs = filteredProvinces;
 	}
-	if (excludeImpassables)
+	if (excludeImpassablesAndWastelands)
 	{
 		std::vector<std::shared_ptr<Province>> filteredProvinces;
-		for (auto &p : relevantProvinces | std::views::filter([](std::shared_ptr<Province> p){ return !p->isImpassable(); })) {
+		for (auto &p : relevantProvs | std::views::filter([](const std::shared_ptr<Province>& p){ return !p->isImpassableOrWasteland(); })) {
 			filteredProvinces.push_back(p);
 		}
-		relevantProvinces = filteredProvinces;
+		relevantProvs = filteredProvinces;
 	}
 
-	return relevantProvinces;
-
-	
+	return relevantProvs;
 }
 
 void UnmappedTab::redrawGrid()
@@ -272,9 +271,9 @@ void UnmappedTab::setExcludeWaterProvinces(bool excludeWaterProvinces)
 	redrawGrid();
 }
 
-void UnmappedTab::setExcludeImpassables(bool excludeImpassables)
+void UnmappedTab::setExcludeImpassablesAndWastelands(bool excludeImpassablesAndWastelands)
 {
-	this->excludeImpassables = excludeImpassables;
+	this->excludeImpassablesAndWastelands = excludeImpassablesAndWastelands;
 	redrawGrid();
 }
 

--- a/ProvinceMapper/Source/Frames/Unmapped/UnmappedTab.h
+++ b/ProvinceMapper/Source/Frames/Unmapped/UnmappedTab.h
@@ -23,7 +23,7 @@ class UnmappedTab final: public wxNotebookPage
 	void removeProvince(const std::string& ID);
 	void addProvince(const std::string& ID);
 	void setExcludeWaterProvinces(bool excludeWaterProvinces);
-	void setExcludeImpassables(bool excludeImpassables);
+	void setExcludeImpassablesAndWastelands(bool excludeImpassablesAndWastelands);
 
   private:
 	void onKeyDown(wxKeyEvent& event);
@@ -51,7 +51,7 @@ class UnmappedTab final: public wxNotebookPage
 	std::shared_ptr<LinkMappingVersion> version;
 	std::map<std::string, int> provinceRows; // province/row
 	bool excludeWaterProvinces = false;
-	bool excludeImpassables = false;
+	bool excludeImpassablesAndWastelands = false;
 
   protected:
 	wxEvtHandler* eventListener = nullptr;

--- a/ProvinceMapper/Source/LinkMapper/Automapper.cpp
+++ b/ProvinceMapper/Source/LinkMapper/Automapper.cpp
@@ -185,7 +185,7 @@ void Automapper::registerMatch(const std::shared_ptr<Province>& srcProvince, con
 	{
 		sourceProvinceShares[srcProvinceID][targetProvinceID] = amount;
 
-		// When registering a new source province, update the cache of impassable source provinces.
+		// When registering a new source province, update the cache of unmappable source provinces.
 		if (srcProvince->isImpassableOrWasteland())
 		{
 			srcImpassablesCache.insert(srcProvinceID);
@@ -200,7 +200,7 @@ void Automapper::registerMatch(const std::shared_ptr<Province>& srcProvince, con
 	{
 		targetProvinceShares[targetProvinceID][srcProvinceID] = amount;
 
-		// When registering a new target province, update the cache of impassable target provinces.
+		// When registering a new target province, update the cache of unmappable target provinces.
 		if (targetProvince->isImpassableOrWasteland())
 		{
 			tgtImpassablesCache.insert(targetProvinceID);

--- a/ProvinceMapper/Source/LinkMapper/Automapper.cpp
+++ b/ProvinceMapper/Source/LinkMapper/Automapper.cpp
@@ -186,7 +186,7 @@ void Automapper::registerMatch(const std::shared_ptr<Province>& srcProvince, con
 		sourceProvinceShares[srcProvinceID][targetProvinceID] = amount;
 
 		// When registering a new source province, update the cache of impassable source provinces.
-		if (srcProvince->isImpassable())
+		if (srcProvince->isImpassableOrWasteland())
 		{
 			srcImpassablesCache.insert(srcProvinceID);
 		}
@@ -201,7 +201,7 @@ void Automapper::registerMatch(const std::shared_ptr<Province>& srcProvince, con
 		targetProvinceShares[targetProvinceID][srcProvinceID] = amount;
 
 		// When registering a new target province, update the cache of impassable target provinces.
-		if (targetProvince->isImpassable())
+		if (targetProvince->isImpassableOrWasteland())
 		{
 			tgtImpassablesCache.insert(targetProvinceID);
 		}

--- a/ProvinceMapper/Source/Provinces/Province.cpp
+++ b/ProvinceMapper/Source/Provinces/Province.cpp
@@ -34,11 +34,12 @@ namespace
 		return mask;
 	}();
 
-	const std::bitset<static_cast<size_t>(ProvinceType::Count)> ImpassableTypesMask = [] {
+	const std::bitset<static_cast<size_t>(ProvinceType::Count)> ImpassableOrWastelandTypesMask = [] {
 		std::bitset<static_cast<size_t>(ProvinceType::Count)> mask;
 		mask.set(static_cast<size_t>(ProvinceType::Wasteland));
 		mask.set(static_cast<size_t>(ProvinceType::ImpassableTerrain));
 		mask.set(static_cast<size_t>(ProvinceType::ImpassableMountains));
+		mask.set(static_cast<size_t>(ProvinceType::NonOwnable));
 		return mask;
 	}();
 
@@ -187,7 +188,7 @@ bool Province::isWater() const
 	return false;
 }
 
-bool Province::isImpassable() const
+bool Province::isImpassableOrWasteland() const
 {
-	return (provinceTypes & ImpassableTypesMask).any();
+	return (provinceTypes & ImpassableOrWastelandTypesMask).any();
 }

--- a/ProvinceMapper/Source/Provinces/Province.cpp
+++ b/ProvinceMapper/Source/Provinces/Province.cpp
@@ -34,6 +34,8 @@ namespace
 		return mask;
 	}();
 
+	// NonOwnable is included because it is a wasteland type - these provinces cannot be owned or settled.
+	// All types in this mask represent provinces that should be excluded from automapping.
 	const std::bitset<static_cast<size_t>(ProvinceType::Count)> ImpassableOrWastelandTypesMask = [] {
 		std::bitset<static_cast<size_t>(ProvinceType::Count)> mask;
 		mask.set(static_cast<size_t>(ProvinceType::Wasteland));

--- a/ProvinceMapper/Source/Provinces/Province.h
+++ b/ProvinceMapper/Source/Provinces/Province.h
@@ -35,7 +35,7 @@ class Province final
 	[[nodiscard]] const std::bitset<static_cast<size_t>(ProvinceType::Count)>& getProvinceTypes() const { return provinceTypes; }
 	[[nodiscard]] bool hasProvinceType(ProvinceType type) const { return provinceTypes.test(static_cast<size_t>(type)); }
 	[[nodiscard]] bool isWater() const;
-	[[nodiscard]] bool isImpassable() const;
+	[[nodiscard]] bool isImpassableOrWasteland() const;
 
 	void setProvinceName(std::string name);
 	void setAreaName(std::string name);


### PR DESCRIPTION
Renamed ImpassableTypesMask to ImpassableOrWastelandTypesMask because non_ownable is a passable province.